### PR TITLE
Add AWS KMS signing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "sha1",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +184,331 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-kms"
+version = "1.103.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6bfd8dfb5a562f9a605bbd5c3aef09db9231c826a1e0488ce3f4338c70dbbb"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.96.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64a6eded248c6b453966e915d32aeddb48ea63ad17932682774eb026fbef5b1"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db96d720d3c622fcbe08bae1c4b04a72ce6257d8b0584cb5418da00ae20a344f"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.100.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fafbdda43b93f57f699c5dfe8328db590b967b8a820a13ccdd6687355dfcc7ca"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "percent-encoding",
+ "sha2",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.13",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.8.1",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.37",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "028999056d2d2fd58a697232f9eec4a643cf73a71cf327690a7edad1d2af2110"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876ab3c9c29791ba4ba02b780a3049e21ec63dabda09268b175272c3733a79e6"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b1117b3b2bbe166d11199b540ceed0d0f7676e36e7b962b5a437a9971eac75"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,10 +518,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -182,8 +549,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -198,6 +565,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -249,6 +626,16 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "cc"
@@ -317,6 +704,16 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -610,6 +1007,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -928,6 +1326,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -937,7 +1354,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -968,6 +1385,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -979,12 +1422,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -995,8 +1449,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1014,6 +1468,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -1022,9 +1500,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -1037,17 +1515,33 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
- "rustls",
+ "rustls 0.23.37",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots",
 ]
@@ -1058,7 +1552,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1075,14 +1569,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1380,7 +1874,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-tungstenite",
  "url",
  "uuid",
@@ -1410,6 +1904,7 @@ dependencies = [
 name = "kelvin-memory-api"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "jsonwebtoken",
  "prost",
  "prost-types",
@@ -1428,6 +1923,10 @@ name = "kelvin-memory-client"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "aws-config",
+ "aws-sdk-kms",
+ "aws-types",
+ "base64",
  "jsonwebtoken",
  "kelvin-core",
  "kelvin-memory-api",
@@ -1435,7 +1934,7 @@ dependencies = [
  "rcgen",
  "serde_json",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tonic",
  "url",
@@ -1454,7 +1953,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tonic",
  "uuid",
  "wasmparser 0.226.0",
@@ -1648,10 +2147,10 @@ dependencies = [
  "bytes",
  "colored",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "log",
  "pin-project-lite",
@@ -1739,6 +2238,18 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
@@ -2075,8 +2586,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
- "socket2",
+ "rustls 0.23.37",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2095,7 +2606,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -2113,7 +2624,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2293,6 +2804,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2309,25 +2826,25 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower",
  "tower-http",
  "tower-service",
@@ -2397,6 +2914,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
@@ -2406,9 +2935,21 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -2428,6 +2969,16 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2464,10 +3015,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2596,6 +3189,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2645,6 +3248,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2845,7 +3458,8 @@ dependencies = [
  "mio",
  "parking_lot",
  "pin-project-lite",
- "socket2",
+ "signal-hook-registry",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2863,11 +3477,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.37",
  "tokio",
 ]
 
@@ -2956,19 +3580,19 @@ dependencies = [
  "axum",
  "base64",
  "bytes",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2",
+ "socket2 0.6.2",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -3043,8 +3667,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -3111,7 +3735,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.8.5",
@@ -3175,6 +3799,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3203,6 +3833,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -4093,6 +4729,12 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yasna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ authors = ["KelvinClaw Contributors"]
 
 [workspace.dependencies]
 async-trait = "0.1"
+aws-config = "1"
+aws-sdk-kms = "1"
+aws-types = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"

--- a/README.md
+++ b/README.md
@@ -425,6 +425,17 @@ Default paths:
 Sign a package manifest and generate `plugin.sig`:
 
 ```bash
+AWS_PROFILE=ah-willsarg-iam scripts/plugin-sign.sh \
+  --manifest ~/.kelvinclaw/plugins/acme.echo/1.0.0/plugin.json \
+  --kms-key-id alias/ah/kelvin/plugins/prod \
+  --kms-region us-east-1 \
+  --publisher-id acme \
+  --trust-policy-out ./trusted_publishers.acme.json
+```
+
+PEM signing remains supported for community publishers and local development:
+
+```bash
 scripts/plugin-sign.sh \
   --manifest ~/.kelvinclaw/plugins/acme.echo/1.0.0/plugin.json \
   --private-key ~/.kelvinclaw/keys/acme-ed25519-private.pem \

--- a/crates/kelvin-memory-api/Cargo.toml
+++ b/crates/kelvin-memory-api/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 build = "build.rs"
 
 [dependencies]
+base64.workspace = true
 jsonwebtoken.workspace = true
 prost.workspace = true
 serde.workspace = true

--- a/crates/kelvin-memory-api/src/lib.rs
+++ b/crates/kelvin-memory-api/src/lib.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -148,6 +149,37 @@ pub fn new_request_id() -> String {
     Uuid::new_v4().to_string()
 }
 
+pub fn delegation_token_signing_input(claims: &DelegationClaims) -> ApiResult<String> {
+    let header = Header::new(JWT_ALGORITHM);
+    let header_json =
+        serde_json::to_vec(&header).map_err(|err| ApiError::Serialization(err.to_string()))?;
+    let claims_json =
+        serde_json::to_vec(claims).map_err(|err| ApiError::Serialization(err.to_string()))?;
+    Ok(format!(
+        "{}.{}",
+        URL_SAFE_NO_PAD.encode(header_json),
+        URL_SAFE_NO_PAD.encode(claims_json)
+    ))
+}
+
+pub fn format_signed_delegation_token(signing_input: &str, signature: &[u8]) -> ApiResult<String> {
+    if signing_input.trim().is_empty() {
+        return Err(ApiError::InvalidInput(
+            "delegation signing input must not be empty".to_string(),
+        ));
+    }
+    if signature.is_empty() {
+        return Err(ApiError::InvalidInput(
+            "delegation signature must not be empty".to_string(),
+        ));
+    }
+    Ok(format!(
+        "{}.{}",
+        signing_input,
+        URL_SAFE_NO_PAD.encode(signature)
+    ))
+}
+
 pub fn mint_delegation_token(claims: &DelegationClaims, key: &EncodingKey) -> ApiResult<String> {
     let header = Header::new(JWT_ALGORITHM);
     encode(&header, claims, key).map_err(|err| ApiError::Token(err.to_string()))
@@ -177,8 +209,8 @@ mod tests {
     use prost_types::FileDescriptorSet;
 
     use super::{
-        mint_delegation_token, verify_delegation_token, DelegationClaims, MemoryOperation,
-        RequestLimits, MEMORY_DESCRIPTOR_SET,
+        delegation_token_signing_input, mint_delegation_token, verify_delegation_token,
+        DelegationClaims, MemoryOperation, RequestLimits, MEMORY_DESCRIPTOR_SET,
     };
     use jsonwebtoken::{DecodingKey, EncodingKey};
 
@@ -244,6 +276,14 @@ mod tests {
         .expect("verify");
         assert_eq!(parsed.module_id, "memory.echo");
         assert!(parsed.allows_operation(MemoryOperation::Query));
+    }
+
+    #[test]
+    fn signing_input_has_expected_jwt_shape() {
+        let input = delegation_token_signing_input(&sample_claims()).expect("signing input");
+        let segments = input.split('.').collect::<Vec<_>>();
+        assert_eq!(segments.len(), 2);
+        assert!(segments.iter().all(|segment| !segment.is_empty()));
     }
 
     #[test]

--- a/crates/kelvin-memory-client/Cargo.toml
+++ b/crates/kelvin-memory-client/Cargo.toml
@@ -7,6 +7,9 @@ authors.workspace = true
 
 [dependencies]
 async-trait.workspace = true
+aws-config.workspace = true
+aws-sdk-kms.workspace = true
+aws-types.workspace = true
 jsonwebtoken.workspace = true
 kelvin-core = { path = "../kelvin-core" }
 kelvin-memory-api = { path = "../kelvin-memory-api" }
@@ -17,6 +20,7 @@ tonic.workspace = true
 url.workspace = true
 
 [dev-dependencies]
+base64.workspace = true
 kelvin-memory-controller = { path = "../kelvin-memory-controller" }
 rcgen = "0.14"
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }

--- a/crates/kelvin-memory-client/src/lib.rs
+++ b/crates/kelvin-memory-client/src/lib.rs
@@ -3,6 +3,11 @@ use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
+use aws_config::BehaviorVersion;
+use aws_sdk_kms::primitives::Blob;
+use aws_sdk_kms::types::{MessageType, SigningAlgorithmSpec};
+use aws_sdk_kms::Client as KmsClient;
+use aws_types::region::Region;
 use jsonwebtoken::EncodingKey;
 use tokio::sync::Mutex;
 use tonic::transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity};
@@ -19,7 +24,8 @@ use kelvin_memory_api::v1alpha1::{
     HealthRequest, QueryRequest, ReadRequest, RequestContext, SearchHit, UpsertRequest,
 };
 use kelvin_memory_api::{
-    mint_delegation_token, new_request_id, DelegationClaims, MemoryOperation, RequestLimits,
+    delegation_token_signing_input, format_signed_delegation_token, mint_delegation_token,
+    new_request_id, DelegationClaims, MemoryOperation, RequestLimits,
 };
 
 #[derive(Debug, Clone)]
@@ -34,6 +40,8 @@ pub struct MemoryClientConfig {
     pub module_id: String,
     pub signing_key_pem: String,
     pub signing_key_path: String,
+    pub signing_kms_key_id: String,
+    pub signing_kms_region: String,
     pub tls_ca_pem: String,
     pub tls_ca_path: String,
     pub tls_domain_name: String,
@@ -60,6 +68,8 @@ impl Default for MemoryClientConfig {
             module_id: "memory.echo".to_string(),
             signing_key_pem: String::new(),
             signing_key_path: String::new(),
+            signing_kms_key_id: String::new(),
+            signing_kms_region: String::new(),
             tls_ca_pem: String::new(),
             tls_ca_path: String::new(),
             tls_domain_name: String::new(),
@@ -128,6 +138,16 @@ impl MemoryClientConfig {
                 cfg.signing_key_path = value;
             }
         }
+        if let Ok(value) = std::env::var("KELVIN_MEMORY_SIGNING_KMS_KEY_ID") {
+            if !value.trim().is_empty() {
+                cfg.signing_kms_key_id = value;
+            }
+        }
+        if let Ok(value) = std::env::var("KELVIN_MEMORY_SIGNING_KMS_REGION") {
+            if !value.trim().is_empty() {
+                cfg.signing_kms_region = value;
+            }
+        }
         if let Ok(value) = std::env::var("KELVIN_MEMORY_RPC_TLS_CA_PEM") {
             if !value.trim().is_empty() {
                 cfg.tls_ca_pem = value;
@@ -193,6 +213,7 @@ impl MemoryClientConfig {
         validate_required_field("memory workspace id", &self.workspace_id)?;
         validate_required_field("memory session id", &self.session_id)?;
         validate_required_field("memory module id", &self.module_id)?;
+        validate_signing_config(self)?;
         if self.timeout_ms == 0 {
             return Err(KelvinError::InvalidInput(
                 "memory timeout must be > 0".to_string(),
@@ -235,21 +256,14 @@ impl MemoryClientConfig {
 
 pub struct RpcMemoryManager {
     cfg: MemoryClientConfig,
-    signer: EncodingKey,
+    signer: Box<dyn DelegationTokenSigner>,
     client: Mutex<MemoryServiceClient<Channel>>,
 }
 
 impl RpcMemoryManager {
     pub async fn connect(cfg: MemoryClientConfig) -> KelvinResult<Self> {
         cfg.validate()?;
-        let signing_key_pem = resolve_required_pem(
-            &cfg.signing_key_pem,
-            &cfg.signing_key_path,
-            "memory rpc signing key",
-        )?;
-        let signer = EncodingKey::from_ed_pem(signing_key_pem.as_bytes()).map_err(|err| {
-            KelvinError::InvalidInput(format!("invalid memory rpc signing key pem: {err}"))
-        })?;
+        let signer = resolve_delegation_token_signer(&cfg).await?;
         let endpoint = build_endpoint(&cfg)?;
         let channel = endpoint.connect().await.map_err(|err| {
             KelvinError::Backend(format!(
@@ -265,7 +279,7 @@ impl RpcMemoryManager {
         })
     }
 
-    fn build_context(
+    async fn build_context(
         &self,
         op: MemoryOperation,
         request_id: String,
@@ -295,8 +309,7 @@ impl RpcMemoryManager {
                 max_results: self.cfg.max_results,
             },
         };
-        let token = mint_delegation_token(&claims, &self.signer)
-            .map_err(|err| KelvinError::InvalidInput(format!("failed to mint token: {err}")))?;
+        let token = self.signer.mint_token(&claims).await?;
         Ok(RequestContext {
             delegation_token: token,
             request_id,
@@ -309,7 +322,9 @@ impl RpcMemoryManager {
 
     pub async fn upsert(&self, key: &str, value: &[u8]) -> KelvinResult<()> {
         let request_id = new_request_id();
-        let context = self.build_context(MemoryOperation::Upsert, request_id)?;
+        let context = self
+            .build_context(MemoryOperation::Upsert, request_id)
+            .await?;
         self.client
             .lock()
             .await
@@ -333,7 +348,9 @@ impl MemorySearchManager for RpcMemoryManager {
         opts: MemorySearchOptions,
     ) -> KelvinResult<Vec<MemorySearchResult>> {
         let request_id = new_request_id();
-        let context = self.build_context(MemoryOperation::Query, request_id)?;
+        let context = self
+            .build_context(MemoryOperation::Query, request_id)
+            .await?;
         let max_results = u32::try_from(opts.max_results)
             .unwrap_or(self.cfg.max_results)
             .min(self.cfg.max_results);
@@ -358,7 +375,9 @@ impl MemorySearchManager for RpcMemoryManager {
 
     async fn read_file(&self, params: MemoryReadParams) -> KelvinResult<MemoryReadResult> {
         let request_id = new_request_id();
-        let context = self.build_context(MemoryOperation::Read, request_id)?;
+        let context = self
+            .build_context(MemoryOperation::Read, request_id)
+            .await?;
         let response = self
             .client
             .lock()
@@ -405,7 +424,9 @@ impl MemorySearchManager for RpcMemoryManager {
 
     async fn sync(&self, _params: Option<MemorySyncParams>) -> KelvinResult<()> {
         let request_id = new_request_id();
-        let context = self.build_context(MemoryOperation::Health, request_id)?;
+        let context = self
+            .build_context(MemoryOperation::Health, request_id)
+            .await?;
         self.client
             .lock()
             .await
@@ -429,6 +450,86 @@ impl MemorySearchManager for RpcMemoryManager {
     }
 }
 
+#[async_trait]
+trait DelegationTokenSigner: Send + Sync {
+    async fn mint_token(&self, claims: &DelegationClaims) -> KelvinResult<String>;
+}
+
+struct PemDelegationTokenSigner {
+    key: EncodingKey,
+}
+
+#[async_trait]
+impl DelegationTokenSigner for PemDelegationTokenSigner {
+    async fn mint_token(&self, claims: &DelegationClaims) -> KelvinResult<String> {
+        mint_delegation_token(claims, &self.key)
+            .map_err(|err| KelvinError::InvalidInput(format!("failed to mint token: {err}")))
+    }
+}
+
+struct KmsDelegationTokenSigner {
+    key_id: String,
+    client: KmsClient,
+}
+
+#[async_trait]
+impl DelegationTokenSigner for KmsDelegationTokenSigner {
+    async fn mint_token(&self, claims: &DelegationClaims) -> KelvinResult<String> {
+        let signing_input = delegation_token_signing_input(claims)
+            .map_err(|err| KelvinError::InvalidInput(format!("failed to prepare token: {err}")))?;
+        let response = self
+            .client
+            .sign()
+            .key_id(&self.key_id)
+            .message(Blob::new(signing_input.as_bytes()))
+            .message_type(MessageType::Raw)
+            .signing_algorithm(SigningAlgorithmSpec::Ed25519Sha512)
+            .send()
+            .await
+            .map_err(|err| {
+                KelvinError::Backend(format!(
+                    "failed to sign memory delegation token with aws kms key '{}': {err}",
+                    self.key_id
+                ))
+            })?;
+        let signature = response.signature().ok_or_else(|| {
+            KelvinError::Backend(format!(
+                "aws kms key '{}' returned no signature for memory delegation token",
+                self.key_id
+            ))
+        })?;
+        format_signed_delegation_token(&signing_input, signature.as_ref()).map_err(|err| {
+            KelvinError::InvalidInput(format!("failed to assemble signed token: {err}"))
+        })
+    }
+}
+
+async fn resolve_delegation_token_signer(
+    cfg: &MemoryClientConfig,
+) -> KelvinResult<Box<dyn DelegationTokenSigner>> {
+    if !cfg.signing_kms_key_id.trim().is_empty() {
+        let mut loader = aws_config::defaults(BehaviorVersion::latest());
+        if !cfg.signing_kms_region.trim().is_empty() {
+            loader = loader.region(Region::new(cfg.signing_kms_region.trim().to_string()));
+        }
+        let shared_config = loader.load().await;
+        return Ok(Box::new(KmsDelegationTokenSigner {
+            key_id: cfg.signing_kms_key_id.trim().to_string(),
+            client: KmsClient::new(&shared_config),
+        }));
+    }
+
+    let signing_key_pem = resolve_required_pem(
+        &cfg.signing_key_pem,
+        &cfg.signing_key_path,
+        "memory rpc signing key",
+    )?;
+    let signer = EncodingKey::from_ed_pem(signing_key_pem.as_bytes()).map_err(|err| {
+        KelvinError::InvalidInput(format!("invalid memory rpc signing key pem: {err}"))
+    })?;
+    Ok(Box::new(PemDelegationTokenSigner { key: signer }))
+}
+
 fn parse_bool(value: &str) -> bool {
     matches!(
         value.to_ascii_lowercase().as_str(),
@@ -447,6 +548,29 @@ fn validate_required_field(label: &str, value: &str) -> KelvinResult<()> {
         return Err(KelvinError::InvalidInput(format!(
             "{label} must not include control characters"
         )));
+    }
+    Ok(())
+}
+
+fn validate_signing_config(cfg: &MemoryClientConfig) -> KelvinResult<()> {
+    let has_kms_key = !cfg.signing_kms_key_id.trim().is_empty();
+    let has_pem = !cfg.signing_key_pem.trim().is_empty() || !cfg.signing_key_path.trim().is_empty();
+
+    if has_kms_key && has_pem {
+        return Err(KelvinError::InvalidInput(
+            "memory signing config cannot set both PEM signing material and KMS signing key"
+                .to_string(),
+        ));
+    }
+    if !has_kms_key && !has_pem {
+        return Err(KelvinError::InvalidInput(
+            "memory signing config requires either PEM signing material or KMS key id".to_string(),
+        ));
+    }
+    if !cfg.signing_kms_region.trim().is_empty() && !has_kms_key {
+        return Err(KelvinError::InvalidInput(
+            "memory signing kms region requires KELVIN_MEMORY_SIGNING_KMS_KEY_ID".to_string(),
+        ));
     }
     Ok(())
 }
@@ -663,5 +787,23 @@ mod tests {
         cfg.signing_key_pem = "placeholder".to_string();
         let err = cfg.validate().expect_err("empty subject should fail");
         assert!(err.to_string().contains("memory rpc subject"));
+    }
+
+    #[test]
+    fn config_validate_accepts_kms_signing_without_pem() {
+        let mut cfg = MemoryClientConfig::default();
+        cfg.signing_kms_key_id = "alias/ah/kelvin/memory-jwt/prod".to_string();
+        cfg.validate().expect("kms signing config should validate");
+    }
+
+    #[test]
+    fn config_validate_rejects_mixed_pem_and_kms_signing() {
+        let mut cfg = MemoryClientConfig::default();
+        cfg.signing_key_pem = "placeholder".to_string();
+        cfg.signing_kms_key_id = "alias/ah/kelvin/memory-jwt/prod".to_string();
+        let err = cfg
+            .validate()
+            .expect_err("mixed signing inputs should fail");
+        assert!(err.to_string().contains("cannot set both"));
     }
 }

--- a/crates/kelvin-memory-client/tests/rpc_integration.rs
+++ b/crates/kelvin-memory-client/tests/rpc_integration.rs
@@ -1,6 +1,11 @@
+use std::env;
 use std::net::SocketAddr;
 use std::sync::OnceLock;
 
+use aws_config::BehaviorVersion;
+use aws_sdk_kms::Client as KmsClient;
+use aws_types::region::Region;
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use rcgen::generate_simple_self_signed;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
@@ -99,17 +104,24 @@ fn ensure_rustls_crypto_provider() {
 }
 
 async fn start_test_server() -> SocketAddr {
-    start_test_server_with_tls(None).await
+    start_test_server_with_public_key(None, test_public_key_pem()).await
 }
 
 async fn start_test_server_with_tls(tls: Option<TestTlsMaterial>) -> SocketAddr {
+    start_test_server_with_public_key(tls, test_public_key_pem()).await
+}
+
+async fn start_test_server_with_public_key(
+    tls: Option<TestTlsMaterial>,
+    decoding_key_pem: String,
+) -> SocketAddr {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
         .expect("bind listener");
     let addr = listener.local_addr().expect("local addr");
 
     let mut cfg = MemoryControllerConfig::default();
-    cfg.decoding_key_pem = test_public_key_pem();
+    cfg.decoding_key_pem = decoding_key_pem;
     let controller =
         MemoryController::new(cfg, ProviderRegistry::with_default_in_memory()).expect("controller");
     controller
@@ -138,6 +150,33 @@ async fn start_test_server_with_tls(tls: Option<TestTlsMaterial>) -> SocketAddr 
     });
 
     addr
+}
+
+fn pem_from_der_public_key(der: &[u8]) -> String {
+    let encoded = STANDARD.encode(der);
+    let mut pem = String::from("-----BEGIN PUBLIC KEY-----\n");
+    for chunk in encoded.as_bytes().chunks(64) {
+        pem.push_str(std::str::from_utf8(chunk).expect("pem chunk"));
+        pem.push('\n');
+    }
+    pem.push_str("-----END PUBLIC KEY-----\n");
+    pem
+}
+
+async fn kms_public_key_pem(key_id: &str, region: &str) -> String {
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .region(Region::new(region.to_string()))
+        .load()
+        .await;
+    let client = KmsClient::new(&config);
+    let output = client
+        .get_public_key()
+        .key_id(key_id)
+        .send()
+        .await
+        .expect("kms get public key");
+    let der = output.public_key().expect("kms public key");
+    pem_from_der_public_key(der.as_ref())
 }
 
 #[tokio::test]
@@ -297,4 +336,38 @@ async fn rpc_memory_manager_mtls_roundtrip_with_client_identity() {
         .expect("search mtls");
     assert_eq!(hits.len(), 1);
     assert_eq!(hits[0].path, "MTLS.md");
+}
+
+#[tokio::test]
+async fn rpc_memory_manager_kms_signing_roundtrip() {
+    let key_id = match env::var("KELVIN_TEST_AWS_KMS_MEMORY_KEY_ID") {
+        Ok(value) if !value.trim().is_empty() => value,
+        _ => return,
+    };
+    let region =
+        env::var("KELVIN_TEST_AWS_KMS_MEMORY_REGION").unwrap_or_else(|_| "us-east-1".to_string());
+    let public_key_pem = kms_public_key_pem(&key_id, &region).await;
+    let addr = start_test_server_with_public_key(None, public_key_pem).await;
+    let cfg = MemoryClientConfig {
+        endpoint: format!("http://{addr}"),
+        signing_kms_key_id: key_id,
+        signing_kms_region: region,
+        tenant_id: "tenant-kms".to_string(),
+        workspace_id: "workspace-kms".to_string(),
+        session_id: "session-kms".to_string(),
+        module_id: "memory.echo".to_string(),
+        ..Default::default()
+    };
+    let manager = RpcMemoryManager::connect(cfg).await.expect("connect kms");
+    manager
+        .upsert("KMS.md", b"kms signer enabled")
+        .await
+        .expect("upsert kms");
+
+    let hits = manager
+        .search("kms signer", Default::default())
+        .await
+        .expect("search kms");
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].path, "KMS.md");
 }

--- a/docs/PLUGIN_INSTALL_FLOW.md
+++ b/docs/PLUGIN_INSTALL_FLOW.md
@@ -164,6 +164,17 @@ Install-time checks validate package integrity and structure. Runtime checks in 
 Generate `plugin.sig` from `plugin.json` and emit trust policy snippet:
 
 ```bash
+AWS_PROFILE=ah-willsarg-iam scripts/plugin-sign.sh \
+  --manifest ./plugin.json \
+  --kms-key-id alias/ah/kelvin/plugins/prod \
+  --kms-region us-east-1 \
+  --publisher-id acme \
+  --trust-policy-out ./trusted_publishers.acme.json
+```
+
+PEM signing remains available for community publishers:
+
+```bash
 scripts/plugin-sign.sh \
   --manifest ./plugin.json \
   --private-key ./acme-ed25519-private.pem \

--- a/docs/memory-controller-deployment-profiles.md
+++ b/docs/memory-controller-deployment-profiles.md
@@ -38,6 +38,14 @@ Controller environment:
 - `KELVIN_MEMORY_TLS_KEY_PEM` or `KELVIN_MEMORY_TLS_KEY_PATH`
 - `KELVIN_MEMORY_TLS_CLIENT_CA_PEM` or `KELVIN_MEMORY_TLS_CLIENT_CA_PATH` (optional mTLS)
 
+Root-side client signing can use:
+
+- `KELVIN_MEMORY_SIGNING_KEY_PEM` or `KELVIN_MEMORY_SIGNING_KEY_PATH`
+- `KELVIN_MEMORY_SIGNING_KMS_KEY_ID` with optional `KELVIN_MEMORY_SIGNING_KMS_REGION`
+
+The controller does not call KMS directly; it verifies against the exported public
+key PEM configured above.
+
 Network safety default:
 
 - Controller refuses non-loopback plaintext binds unless either:

--- a/docs/memory-rpc-contract.md
+++ b/docs/memory-rpc-contract.md
@@ -21,11 +21,15 @@ Source: `crates/kelvin-memory-api/proto/kelvin/memory/v1alpha1/memory.proto`
 - Optional mTLS can be enabled by configuring controller client-CA and client cert/key on root-side client.
 - Root client JWT signing key:
 - `KELVIN_MEMORY_SIGNING_KEY_PEM` or `KELVIN_MEMORY_SIGNING_KEY_PATH`
+- or `KELVIN_MEMORY_SIGNING_KMS_KEY_ID` with optional `KELVIN_MEMORY_SIGNING_KMS_REGION`
 - Root client TLS knobs:
 - `KELVIN_MEMORY_RPC_TLS_CA_PEM` or `KELVIN_MEMORY_RPC_TLS_CA_PATH`
 - `KELVIN_MEMORY_RPC_TLS_DOMAIN_NAME`
 - `KELVIN_MEMORY_RPC_TLS_CLIENT_CERT_PEM` or `KELVIN_MEMORY_RPC_TLS_CLIENT_CERT_PATH`
 - `KELVIN_MEMORY_RPC_TLS_CLIENT_KEY_PEM` or `KELVIN_MEMORY_RPC_TLS_CLIENT_KEY_PATH`
+
+For KMS-backed signing, controller verification still uses an exported public key via
+`KELVIN_MEMORY_PUBLIC_KEY_PEM` or `KELVIN_MEMORY_PUBLIC_KEY_PATH`.
 
 ## Required Context
 

--- a/docs/plugin-author-kit.md
+++ b/docs/plugin-author-kit.md
@@ -46,6 +46,17 @@ For new model plugins, prefer the generic host-routed `provider_profile` field (
 ## Signing
 
 ```bash
+AWS_PROFILE=ah-willsarg-iam scripts/plugin-sign.sh \
+  --manifest ./plugin-acme.echo/plugin.json \
+  --kms-key-id alias/ah/kelvin/plugins/prod \
+  --kms-region us-east-1 \
+  --publisher-id acme \
+  --trust-policy-out ./trusted_publishers.acme.json
+```
+
+For non-AgenticHighway publishers, the local PEM flow remains available:
+
+```bash
 scripts/plugin-sign.sh \
   --manifest ./plugin-acme.echo/plugin.json \
   --private-key /path/to/ed25519-private.pem \

--- a/docs/runbooks/memory-jwt-key-rotation.md
+++ b/docs/runbooks/memory-jwt-key-rotation.md
@@ -6,13 +6,13 @@ Rotate Root signing keys used for memory delegation JWTs without downtime.
 
 ## Procedure
 
-1. Generate a new Ed25519 keypair offline.
-2. Publish new public key to controller config (`KELVIN_MEMORY_PUBLIC_KEY_PEM`) as staged value.
-3. Deploy controller with acceptance window for both old/new issuers if needed.
-4. Update Root to mint tokens with new private key.
+1. Create or rotate the Ed25519 signer in AWS KMS.
+2. Export the new public key PEM from KMS and stage it into controller config (`KELVIN_MEMORY_PUBLIC_KEY_PEM` or `KELVIN_MEMORY_PUBLIC_KEY_PATH`).
+3. Deploy controller with the staged verifier and acceptance window for both old/new issuers if needed.
+4. Update Root to mint tokens with `KELVIN_MEMORY_SIGNING_KMS_KEY_ID` and optional `KELVIN_MEMORY_SIGNING_KMS_REGION`.
 5. Observe memory RPC success/error rates and token verification failures.
-6. Remove old public key acceptance after steady-state window.
-7. Revoke and securely destroy old private key material.
+6. Remove old public key acceptance after the steady-state window.
+7. Disable and schedule deletion for the old KMS key, or securely destroy legacy offline key material after migration.
 
 ## Validation
 

--- a/scripts/kms-ed25519-public-key.sh
+++ b/scripts/kms-ed25519-public-key.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KMS_KEY_ID=""
+KMS_REGION=""
+FORMAT="pem"
+PUBLISHER_ID=""
+OUTPUT_PATH=""
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/kms-ed25519-public-key.sh --kms-key-id <key-id-or-alias> [options]
+
+Fetches an AWS KMS Ed25519 public key and emits it in one of the formats Kelvin uses.
+
+Required:
+  --kms-key-id <id>        KMS key id, ARN, or alias
+
+Optional:
+  --kms-region <region>    AWS region override (default: SDK/CLI resolution)
+  --format <name>          Output format: pem | raw-base64 | trust-policy
+  --publisher-id <id>      Publisher id required for trust-policy output
+  --output <path>          Write output to a file instead of stdout
+  -h, --help               Show this help
+
+Examples:
+  AWS_PROFILE=ah-willsarg-iam scripts/kms-ed25519-public-key.sh \
+    --kms-key-id alias/ah/kelvin/plugins/prod \
+    --kms-region us-east-1 \
+    --format raw-base64
+
+  AWS_PROFILE=ah-willsarg-iam scripts/kms-ed25519-public-key.sh \
+    --kms-key-id alias/ah/kelvin/plugins/prod \
+    --kms-region us-east-1 \
+    --format trust-policy \
+    --publisher-id kelvin_firstparty_aws_v1 \
+    --output ./trusted_publishers.kelvin.json
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --kms-key-id)
+      KMS_KEY_ID="${2:?missing value for --kms-key-id}"
+      shift 2
+      ;;
+    --kms-region)
+      KMS_REGION="${2:?missing value for --kms-region}"
+      shift 2
+      ;;
+    --format)
+      FORMAT="${2:?missing value for --format}"
+      shift 2
+      ;;
+    --publisher-id)
+      PUBLISHER_ID="${2:?missing value for --publisher-id}"
+      shift 2
+      ;;
+    --output)
+      OUTPUT_PATH="${2:?missing value for --output}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+require_cmd() {
+  local name="$1"
+  if ! command -v "${name}" >/dev/null 2>&1; then
+    echo "Missing required command: ${name}" >&2
+    exit 1
+  fi
+}
+
+require_cmd aws
+require_cmd jq
+require_cmd openssl
+require_cmd awk
+require_cmd xxd
+
+resolve_openssl_cmd() {
+  local candidate=""
+  for candidate in \
+    "/opt/homebrew/opt/openssl@3/bin/openssl" \
+    "/usr/local/opt/openssl@3/bin/openssl"
+  do
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  printf '%s\n' "openssl"
+}
+
+if [[ -z "${KMS_KEY_ID}" ]]; then
+  echo "Missing required arguments." >&2
+  usage
+  exit 1
+fi
+
+case "${FORMAT}" in
+  pem|raw-base64|trust-policy)
+    ;;
+  *)
+    echo "Unsupported format: ${FORMAT}" >&2
+    exit 1
+    ;;
+esac
+
+if [[ "${FORMAT}" == "trust-policy" && -z "${PUBLISHER_ID}" ]]; then
+  echo "--publisher-id is required when --format trust-policy is used." >&2
+  exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+OPENSSL_BIN="$(resolve_openssl_cmd)"
+PUB_DER_PATH="${WORK_DIR}/public.der"
+PUB_PEM_PATH="${WORK_DIR}/public.pem"
+
+AWS_ARGS=(aws)
+if [[ -n "${KMS_REGION}" ]]; then
+  AWS_ARGS+=(--region "${KMS_REGION}")
+fi
+AWS_ARGS+=(
+  kms
+  get-public-key
+  --key-id "${KMS_KEY_ID}"
+  --output json
+)
+
+AWS_RESPONSE="$("${AWS_ARGS[@]}")"
+KEY_SPEC="$(printf '%s' "${AWS_RESPONSE}" | jq -r '.KeySpec // empty')"
+if [[ "${KEY_SPEC}" != "ECC_NIST_EDWARDS25519" ]]; then
+  echo "KMS key '${KMS_KEY_ID}' must use KeySpec ECC_NIST_EDWARDS25519; got '${KEY_SPEC}'." >&2
+  exit 1
+fi
+
+PUB_DER_B64="$(printf '%s' "${AWS_RESPONSE}" | jq -er '.PublicKey')"
+printf '%s' "${PUB_DER_B64}" | "${OPENSSL_BIN}" base64 -d -A > "${PUB_DER_PATH}"
+"${OPENSSL_BIN}" pkey -pubin -inform DER -in "${PUB_DER_PATH}" -outform PEM -out "${PUB_PEM_PATH}" >/dev/null 2>&1
+
+PUB_HEX="$(
+  "${OPENSSL_BIN}" pkey -pubin -inform DER -in "${PUB_DER_PATH}" -text -noout 2>/dev/null \
+    | awk '
+      /^pub:/ {capture=1; next}
+      capture && /^[[:space:]]*$/ {capture=0; next}
+      capture {gsub(/[ :]/, "", $0); printf "%s", $0}
+    '
+)"
+
+if [[ ${#PUB_HEX} -ne 64 ]]; then
+  echo "Failed to derive a raw 32-byte Ed25519 public key from KMS output." >&2
+  exit 1
+fi
+
+PUB_RAW_B64="$(printf '%s' "${PUB_HEX}" | xxd -r -p | "${OPENSSL_BIN}" base64 -A)"
+
+case "${FORMAT}" in
+  pem)
+    RESULT="$(cat "${PUB_PEM_PATH}")"
+    ;;
+  raw-base64)
+    RESULT="${PUB_RAW_B64}"
+    ;;
+  trust-policy)
+    RESULT="$(
+      jq -n \
+        --arg publisher_id "${PUBLISHER_ID}" \
+        --arg public_key "${PUB_RAW_B64}" \
+        '{
+          require_signature: true,
+          publishers: [
+            {
+              id: $publisher_id,
+              ed25519_public_key: $public_key
+            }
+          ]
+        }'
+    )"
+    ;;
+esac
+
+if [[ -n "${OUTPUT_PATH}" ]]; then
+  printf '%s\n' "${RESULT}" > "${OUTPUT_PATH}"
+  echo "Wrote ${FORMAT} output: ${OUTPUT_PATH}"
+else
+  printf '%s\n' "${RESULT}"
+fi

--- a/scripts/plugin-sign.sh
+++ b/scripts/plugin-sign.sh
@@ -3,27 +3,39 @@ set -euo pipefail
 
 MANIFEST_PATH=""
 PRIVATE_KEY_PATH=""
+KMS_KEY_ID=""
+KMS_REGION=""
 SIGNATURE_PATH=""
 PUBLISHER_ID=""
 TRUST_POLICY_OUT=""
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/plugin-sign.sh --manifest <plugin.json> --private-key <ed25519-private-key.pem> [options]
+Usage: scripts/plugin-sign.sh --manifest <plugin.json> (--private-key <ed25519-private-key.pem> | --kms-key-id <key-id-or-alias>) [options]
 
 Signs a plugin manifest and writes plugin.sig (base64 signature) for Kelvin installed-plugin verification.
 
 Required:
   --manifest <path>        Path to plugin.json to sign
-  --private-key <path>     Ed25519 private key in PEM format
+  exactly one of:
+    --private-key <path>   Ed25519 private key in PEM format
+    --kms-key-id <id>      AWS KMS Ed25519 key id, ARN, or alias
 
 Optional:
   --output <path>          Signature output path (default: <manifest_dir>/plugin.sig)
+  --kms-region <region>    AWS region override for KMS mode
   --publisher-id <id>      Publisher id for trust policy snippet output
   --trust-policy-out <path>Write trusted_publishers.json snippet with derived public key
   -h, --help               Show this help
 
 Example:
+  AWS_PROFILE=ah-willsarg-iam scripts/plugin-sign.sh \
+    --manifest ~/.kelvinclaw/plugins/acme.echo/1.0.0/plugin.json \
+    --kms-key-id alias/ah/kelvin/plugins/prod \
+    --kms-region us-east-1 \
+    --publisher-id acme \
+    --trust-policy-out ./trusted_publishers.acme.json
+
   scripts/plugin-sign.sh \
     --manifest ~/.kelvinclaw/plugins/acme.echo/1.0.0/plugin.json \
     --private-key ~/.kelvinclaw/keys/acme-ed25519-private.pem \
@@ -40,6 +52,14 @@ while [[ $# -gt 0 ]]; do
       ;;
     --private-key)
       PRIVATE_KEY_PATH="${2:?missing value for --private-key}"
+      shift 2
+      ;;
+    --kms-key-id)
+      KMS_KEY_ID="${2:?missing value for --kms-key-id}"
+      shift 2
+      ;;
+    --kms-region)
+      KMS_REGION="${2:?missing value for --kms-region}"
       shift 2
       ;;
     --output)
@@ -79,9 +99,32 @@ require_cmd awk
 require_cmd xxd
 require_cmd jq
 
-if [[ -z "${MANIFEST_PATH}" || -z "${PRIVATE_KEY_PATH}" ]]; then
+resolve_openssl_cmd() {
+  local candidate=""
+  for candidate in \
+    "/opt/homebrew/opt/openssl@3/bin/openssl" \
+    "/usr/local/opt/openssl@3/bin/openssl"
+  do
+    if [[ -x "${candidate}" ]]; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+  printf '%s\n' "openssl"
+}
+
+if [[ -z "${MANIFEST_PATH}" ]]; then
   echo "Missing required arguments." >&2
   usage
+  exit 1
+fi
+
+if [[ -n "${PRIVATE_KEY_PATH}" && -n "${KMS_KEY_ID}" ]]; then
+  echo "--private-key and --kms-key-id are mutually exclusive." >&2
+  exit 1
+fi
+if [[ -z "${PRIVATE_KEY_PATH}" && -z "${KMS_KEY_ID}" ]]; then
+  echo "Either --private-key or --kms-key-id is required." >&2
   exit 1
 fi
 
@@ -89,7 +132,21 @@ if [[ ! -f "${MANIFEST_PATH}" ]]; then
   echo "Manifest not found: ${MANIFEST_PATH}" >&2
   exit 1
 fi
-if [[ ! -f "${PRIVATE_KEY_PATH}" ]]; then
+
+MANIFEST_PATH="$(cd "$(dirname "${MANIFEST_PATH}")" && pwd)/$(basename "${MANIFEST_PATH}")"
+if [[ -n "${PRIVATE_KEY_PATH}" ]]; then
+  if [[ ! -f "${PRIVATE_KEY_PATH}" ]]; then
+    echo "Private key not found: ${PRIVATE_KEY_PATH}" >&2
+    exit 1
+  fi
+  PRIVATE_KEY_PATH="$(cd "$(dirname "${PRIVATE_KEY_PATH}")" && pwd)/$(basename "${PRIVATE_KEY_PATH}")"
+fi
+
+if [[ -n "${KMS_KEY_ID}" ]]; then
+  require_cmd aws
+fi
+
+if [[ -n "${PRIVATE_KEY_PATH}" && ! -f "${PRIVATE_KEY_PATH}" ]]; then
   echo "Private key not found: ${PRIVATE_KEY_PATH}" >&2
   exit 1
 fi
@@ -104,38 +161,71 @@ cleanup() {
 }
 trap cleanup EXIT
 
+OPENSSL_BIN="$(resolve_openssl_cmd)"
 SIG_BIN_PATH="${WORK_DIR}/plugin.sig.bin"
-
-# Ed25519 signs raw message bytes; plugin runtime verifies plugin.sig over plugin.json bytes.
-openssl pkeyutl -sign -inkey "${PRIVATE_KEY_PATH}" -rawin -in "${MANIFEST_PATH}" -out "${SIG_BIN_PATH}"
-openssl base64 -A -in "${SIG_BIN_PATH}" > "${SIGNATURE_PATH}"
-
-# Verify signature immediately before returning success.
 PUB_PEM_PATH="${WORK_DIR}/public.pem"
-openssl pkey -in "${PRIVATE_KEY_PATH}" -pubout -out "${PUB_PEM_PATH}" >/dev/null 2>&1
-if ! openssl pkeyutl -verify -pubin -inkey "${PUB_PEM_PATH}" -rawin -in "${MANIFEST_PATH}" -sigfile "${SIG_BIN_PATH}" >/dev/null 2>&1; then
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+KMS_PUBLIC_KEY_HELPER="${SCRIPT_DIR}/kms-ed25519-public-key.sh"
+
+if [[ -n "${PRIVATE_KEY_PATH}" ]]; then
+  # Ed25519 signs raw message bytes; plugin runtime verifies plugin.sig over plugin.json bytes.
+  "${OPENSSL_BIN}" pkeyutl -sign -inkey "${PRIVATE_KEY_PATH}" -rawin -in "${MANIFEST_PATH}" -out "${SIG_BIN_PATH}"
+  "${OPENSSL_BIN}" base64 -A -in "${SIG_BIN_PATH}" > "${SIGNATURE_PATH}"
+
+  # Verify signature immediately before returning success.
+  "${OPENSSL_BIN}" pkey -in "${PRIVATE_KEY_PATH}" -pubout -out "${PUB_PEM_PATH}" >/dev/null 2>&1
+else
+  if [[ ! -x "${KMS_PUBLIC_KEY_HELPER}" ]]; then
+    echo "KMS public key helper is missing or not executable: ${KMS_PUBLIC_KEY_HELPER}" >&2
+    exit 1
+  fi
+  AWS_ARGS=(aws)
+  HELPER_ARGS=(
+    --kms-key-id "${KMS_KEY_ID}"
+  )
+  if [[ -n "${KMS_REGION}" ]]; then
+    AWS_ARGS+=(--region "${KMS_REGION}")
+    HELPER_ARGS+=(--kms-region "${KMS_REGION}")
+  fi
+  KMS_RESPONSE="$("${AWS_ARGS[@]}" kms sign \
+    --key-id "${KMS_KEY_ID}" \
+    --message "fileb://${MANIFEST_PATH}" \
+    --message-type RAW \
+    --signing-algorithm ED25519_SHA_512 \
+    --output json)"
+  SIG_B64="$(printf '%s' "${KMS_RESPONSE}" | jq -er '.Signature')"
+  printf '%s' "${SIG_B64}" > "${SIGNATURE_PATH}"
+  printf '%s' "${SIG_B64}" | "${OPENSSL_BIN}" base64 -d -A > "${SIG_BIN_PATH}"
+  "${KMS_PUBLIC_KEY_HELPER}" "${HELPER_ARGS[@]}" --format pem --output "${PUB_PEM_PATH}" >/dev/null
+fi
+
+if ! "${OPENSSL_BIN}" pkeyutl -verify -pubin -inkey "${PUB_PEM_PATH}" -rawin -in "${MANIFEST_PATH}" -sigfile "${SIG_BIN_PATH}" >/dev/null 2>&1; then
   echo "Signature verification failed after signing; refusing to continue." >&2
   exit 1
 fi
 
 echo "Wrote signature: ${SIGNATURE_PATH}"
 
-# Derive raw 32-byte Ed25519 public key and emit base64 for Kelvin trust policy.
-PUB_HEX="$(
-  openssl pkey -in "${PRIVATE_KEY_PATH}" -pubout -text -noout 2>/dev/null \
-    | awk '
-      /^pub:/ {capture=1; next}
-      capture && /^[[:space:]]*$/ {capture=0; next}
-      capture {gsub(/[ :]/, "", $0); printf "%s", $0}
-    '
-)"
+if [[ -n "${PRIVATE_KEY_PATH}" ]]; then
+  # Derive raw 32-byte Ed25519 public key and emit base64 for Kelvin trust policy.
+  PUB_HEX="$(
+    "${OPENSSL_BIN}" pkey -in "${PRIVATE_KEY_PATH}" -pubout -text -noout 2>/dev/null \
+      | awk '
+        /^pub:/ {capture=1; next}
+        capture && /^[[:space:]]*$/ {capture=0; next}
+        capture {gsub(/[ :]/, "", $0); printf "%s", $0}
+      '
+  )"
 
-if [[ ${#PUB_HEX} -ne 64 ]]; then
-  echo "Failed to derive a raw 32-byte Ed25519 public key from private key." >&2
-  exit 1
+  if [[ ${#PUB_HEX} -ne 64 ]]; then
+    echo "Failed to derive a raw 32-byte Ed25519 public key from private key." >&2
+    exit 1
+  fi
+
+  PUB_B64="$(printf '%s' "${PUB_HEX}" | xxd -r -p | "${OPENSSL_BIN}" base64 -A)"
+else
+  PUB_B64="$("${KMS_PUBLIC_KEY_HELPER}" "${HELPER_ARGS[@]}" --format raw-base64)"
 fi
-
-PUB_B64="$(printf '%s' "${PUB_HEX}" | xxd -r -p | openssl base64 -A)"
 echo "Derived publisher public key (base64): ${PUB_B64}"
 
 if [[ -n "${TRUST_POLICY_OUT}" ]]; then

--- a/templates/plugin-author-kit/README.md
+++ b/templates/plugin-author-kit/README.md
@@ -21,5 +21,7 @@ New model plugins should declare a `provider_profile` such as `openai.responses`
 Signing and trust policy:
 
 ```bash
-scripts/plugin-sign.sh --manifest ./plugin.json --private-key /path/to/private.pem --publisher-id acme --trust-policy-out ./trusted_publishers.acme.json
+AWS_PROFILE=ah-willsarg-iam scripts/plugin-sign.sh --manifest ./plugin.json --kms-key-id alias/ah/kelvin/plugins/prod --kms-region us-east-1 --publisher-id acme --trust-policy-out ./trusted_publishers.acme.json
 ```
+
+Community publishers can continue using `--private-key /path/to/private.pem` instead of `--kms-key-id`.


### PR DESCRIPTION
## Summary
- add AWS KMS-backed plugin signing and public-key export helpers
- add KMS-backed memory JWT signing while keeping PEM fallback
- update signing and rotation docs for the new first-party flow

## Validation
- terraform validate for the supporting infra stack
- cargo test -p kelvin-memory-api -q
- cargo test -p kelvin-memory-client -q
- cargo test -p kelvin-memory-client rpc_memory_manager_kms_signing_roundtrip -q
- live KMS plugin signing smoke and kelvin-host plugin smoke