### PR TITLE
Add Linux release executable workflow

### DIFF
--- a/.github/workflows/release-linux-executables.yml
+++ b/.github/workflows/release-linux-executables.yml
@@ -1,0 +1,75 @@
+name: Release Linux Executables
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-linux-executables-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: blacksmith-4vcpu-ubuntu-2404
+            target: x86_64-unknown-linux-gnu
+          - runner: blacksmith-4vcpu-ubuntu-2404-arm
+            target: aarch64-unknown-linux-gnu
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+        with:
+          toolchain: stable
+
+      - name: Build and package Linux executables
+        run: scripts/package-linux-release.sh --target "${{ matrix.target }}"
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: release-${{ matrix.target }}
+          path: |
+            dist/releases/*.tar.gz
+            dist/releases/*.tar.gz.sha256
+          if-no-files-found: error
+          retention-days: 14
+
+  publish:
+    name: Publish GitHub Release
+    if: ${{ github.event_name == 'push' }}
+    needs: build
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Publish release assets
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b
+        with:
+          files: |
+            release-assets/*.tar.gz
+            release-assets/*.tar.gz.sha256
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -36,6 +36,20 @@ scripts/verify-onboarding.sh --track wasm
 scripts/verify-onboarding.sh --track daily
 ```
 
+## Linux Release Executables
+
+Tagged releases publish Linux executable bundles for:
+
+- `kelvin-host`
+- `kelvin-gateway`
+- `kelvin-memory-controller`
+- `kelvin-registry`
+
+The release workflow is backed by Blacksmith runners and produces native
+`linux-x86_64` and `linux-arm64` tarballs with matching SHA-256 files.
+For manual validation without publishing a GitHub Release, run the
+`Release Linux Executables` workflow with `workflow_dispatch`.
+
 ## Repository Layout
 
 - `apps/kelvin-host`: thin trusted host executable

--- a/crates/kelvin-memory-controller/src/bin/kelvin-memory-controller.rs
+++ b/crates/kelvin-memory-controller/src/bin/kelvin-memory-controller.rs
@@ -8,6 +8,26 @@ use kelvin_memory_api::v1alpha1::memory_service_server::MemoryServiceServer;
 use kelvin_memory_api::MemoryModuleManifest;
 use kelvin_memory_controller::{MemoryController, MemoryControllerConfig, ProviderRegistry};
 
+fn usage() -> &'static str {
+    "Usage: kelvin-memory-controller [--help]"
+}
+
+fn handle_cli() -> Result<(), String> {
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "-h" | "--help" => {
+                println!("{}", usage());
+                std::process::exit(0);
+            }
+            _ => {
+                return Err(format!("unknown argument: {arg}\n{}", usage()));
+            }
+        }
+    }
+    Ok(())
+}
+
 fn ensure_rustls_crypto_provider() {
     static RUSTLS_PROVIDER: OnceLock<()> = OnceLock::new();
     let _ = RUSTLS_PROVIDER.get_or_init(|| {
@@ -17,6 +37,10 @@ fn ensure_rustls_crypto_provider() {
 
 #[tokio::main]
 async fn main() {
+    if let Err(err) = handle_cli() {
+        eprintln!("{err}");
+        std::process::exit(1);
+    }
     if let Err(err) = run().await {
         eprintln!("error: {err}");
         std::process::exit(1);

--- a/scripts/kelvin-plugin.sh
+++ b/scripts/kelvin-plugin.sh
@@ -13,6 +13,40 @@ require_cmd() {
   fi
 }
 
+create_tar_gz() {
+  local output_path="$1"
+  local base_dir="$2"
+  shift 2
+  local stage_dir=""
+  local rel_path=""
+  local src_path=""
+
+  local -a tar_args=(--format ustar -czf "${output_path}")
+  if tar --help 2>/dev/null | grep -q -- '--sort='; then
+    tar_args=(--sort=name --mtime='UTC 1970-01-01' --owner=0 --group=0 --numeric-owner "${tar_args[@]}")
+  fi
+  if tar --help 2>/dev/null | grep -q -- '--pax-option'; then
+    tar_args=(--pax-option=delete=atime,delete=ctime "${tar_args[@]}")
+  fi
+
+  stage_dir="$(mktemp -d)"
+  for rel_path in "$@"; do
+    src_path="${base_dir}/${rel_path}"
+    mkdir -p "${stage_dir}/$(dirname "${rel_path}")"
+    if [[ -d "${src_path}" ]]; then
+      cp -R "${src_path}" "${stage_dir}/${rel_path}"
+    else
+      cp -p "${src_path}" "${stage_dir}/${rel_path}"
+    fi
+  done
+  if command -v xattr >/dev/null 2>&1; then
+    xattr -rc "${stage_dir}" >/dev/null 2>&1 || true
+  fi
+
+  COPYFILE_DISABLE=1 COPY_EXTENDED_ATTRIBUTES_DISABLE=1 tar "${tar_args[@]}" -C "${stage_dir}" "$@"
+  rm -rf "${stage_dir}"
+}
+
 sha256_file() {
   local file="$1"
   if command -v shasum >/dev/null 2>&1; then
@@ -504,7 +538,7 @@ cmd_pack() {
   if [[ -f "${manifest_dir}/plugin.sig" ]]; then
     include_sig="plugin.sig"
   fi
-  tar -czf "${output}" -C "${manifest_dir}" plugin.json payload ${include_sig}
+  create_tar_gz "${output}" "${manifest_dir}" plugin.json payload ${include_sig}
   echo "[kelvin-plugin] package created: ${output}"
 }
 

--- a/scripts/package-linux-release.sh
+++ b/scripts/package-linux-release.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${ROOT_DIR}/dist/releases"
+TARGET=""
+VERSION=""
+TARGET_DIR="${ROOT_DIR}/target/releases"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/package-linux-release.sh --target <target-triple> [options]
+
+Build KelvinClaw release executables for a Linux target, package them into a
+deterministic tarball, and smoke-test the packaged binaries.
+
+Options:
+  --target <triple>        Required Rust target triple
+  --output-dir <path>      Directory for release tarballs (default: ./dist/releases)
+  --target-dir <path>      Cargo target dir (default: ./target/releases)
+  --version <semver>       Override version label (default: workspace version)
+  -h, --help               Show help
+USAGE
+}
+
+require_cmd() {
+  local name="$1"
+  if ! command -v "${name}" >/dev/null 2>&1; then
+    echo "Missing required command: ${name}" >&2
+    exit 1
+  fi
+}
+
+sha256_file() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${file}" | awk '{print $1}'
+    return 0
+  fi
+  shasum -a 256 "${file}" | awk '{print $1}'
+}
+
+platform_label() {
+  case "$1" in
+    x86_64-unknown-linux-gnu) printf '%s\n' 'linux-x86_64' ;;
+    aarch64-unknown-linux-gnu) printf '%s\n' 'linux-arm64' ;;
+    *) echo "Unsupported target triple: $1" >&2; exit 1 ;;
+  esac
+}
+
+workspace_version() {
+  cargo metadata --no-deps --format-version 1 \
+    | jq -r '.packages[] | select(.name == "kelvin-host") | .version'
+}
+
+create_tar_gz() {
+  local output_path="$1"
+  local base_dir="$2"
+  local root_name="$3"
+
+  tar \
+    --sort=name \
+    --mtime='UTC 1970-01-01' \
+    --owner=0 \
+    --group=0 \
+    --numeric-owner \
+    -czf "${output_path}" \
+    -C "${base_dir}" \
+    "${root_name}"
+}
+
+smoke_test_archive() {
+  local archive_path="$1"
+  local root_name="$2"
+  local work_dir=""
+
+  work_dir="$(mktemp -d)"
+  tar -xzf "${archive_path}" -C "${work_dir}"
+  "${work_dir}/${root_name}/bin/kelvin-host" --help >/dev/null
+  "${work_dir}/${root_name}/bin/kelvin-gateway" --help >/dev/null
+  "${work_dir}/${root_name}/bin/kelvin-registry" --help >/dev/null
+  "${work_dir}/${root_name}/bin/kelvin-memory-controller" --help >/dev/null
+  rm -rf "${work_dir}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      TARGET="${2:?missing value for --target}"
+      shift 2
+      ;;
+    --output-dir)
+      OUTPUT_DIR="${2:?missing value for --output-dir}"
+      shift 2
+      ;;
+    --target-dir)
+      TARGET_DIR="${2:?missing value for --target-dir}"
+      shift 2
+      ;;
+    --version)
+      VERSION="${2:?missing value for --version}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+[[ -n "${TARGET}" ]] || {
+  echo "--target is required" >&2
+  usage
+  exit 1
+}
+
+require_cmd cargo
+require_cmd jq
+require_cmd tar
+require_cmd rustup
+
+if [[ -z "${VERSION}" ]]; then
+  VERSION="$(workspace_version)"
+fi
+
+PLATFORM_LABEL="$(platform_label "${TARGET}")"
+ARCHIVE_ROOT="kelvinclaw-${VERSION}-${PLATFORM_LABEL}"
+ARCHIVE_PATH="${OUTPUT_DIR}/${ARCHIVE_ROOT}.tar.gz"
+CHECKSUM_PATH="${ARCHIVE_PATH}.sha256"
+STAGE_PARENT="$(mktemp -d)"
+STAGE_ROOT="${STAGE_PARENT}/${ARCHIVE_ROOT}"
+
+cleanup() {
+  rm -rf "${STAGE_PARENT}"
+}
+trap cleanup EXIT
+
+mkdir -p "${OUTPUT_DIR}" "${STAGE_ROOT}/bin"
+
+rustup target add "${TARGET}" >/dev/null
+
+CARGO_TARGET_DIR="${TARGET_DIR}" cargo build --locked --release --target "${TARGET}" -p kelvin-host
+CARGO_TARGET_DIR="${TARGET_DIR}" cargo build --locked --release --target "${TARGET}" -p kelvin-gateway --features memory_rpc
+CARGO_TARGET_DIR="${TARGET_DIR}" cargo build --locked --release --target "${TARGET}" -p kelvin-registry
+CARGO_TARGET_DIR="${TARGET_DIR}" cargo build --locked --release --target "${TARGET}" -p kelvin-memory-controller
+
+cp "${TARGET_DIR}/${TARGET}/release/kelvin-host" "${STAGE_ROOT}/bin/"
+cp "${TARGET_DIR}/${TARGET}/release/kelvin-gateway" "${STAGE_ROOT}/bin/"
+cp "${TARGET_DIR}/${TARGET}/release/kelvin-registry" "${STAGE_ROOT}/bin/"
+cp "${TARGET_DIR}/${TARGET}/release/kelvin-memory-controller" "${STAGE_ROOT}/bin/"
+cp "${ROOT_DIR}/LICENSE" "${STAGE_ROOT}/"
+cp "${ROOT_DIR}/README.md" "${STAGE_ROOT}/"
+
+cat > "${STAGE_ROOT}/BUILD_INFO.txt" <<EOF
+version=${VERSION}
+target=${TARGET}
+platform=${PLATFORM_LABEL}
+EOF
+
+rm -f "${ARCHIVE_PATH}" "${CHECKSUM_PATH}"
+create_tar_gz "${ARCHIVE_PATH}" "${STAGE_PARENT}" "${ARCHIVE_ROOT}"
+printf '%s  %s\n' "$(sha256_file "${ARCHIVE_PATH}")" "$(basename "${ARCHIVE_PATH}")" > "${CHECKSUM_PATH}"
+smoke_test_archive "${ARCHIVE_PATH}" "${ARCHIVE_ROOT}"
+
+echo "archive=${ARCHIVE_PATH}"
+echo "checksum=${CHECKSUM_PATH}"


### PR DESCRIPTION
## Summary
- add a Blacksmith-backed workflow that builds native Linux x86_64 and arm64 release bundles
- add a packaging script that emits deterministic tarballs and SHA-256 files
- add a packaged-binary smoke test and consistent help output for kelvin-memory-controller

## Testing
- bash -n scripts/package-linux-release.sh
- git diff --check
- Ubuntu container: scripts/package-linux-release.sh --target aarch64-unknown-linux-gnu
