### PR TITLE
Document release quickstart onboarding

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -3,6 +3,66 @@
 KelvinClaw supports three onboarding tracks based on user experience level.
 Each track has a verification command so the setup can be validated immediately.
 
+## Release Quickstart (Validated Public Onboarding)
+
+Use this if you want the fastest path from a public release tarball to a real
+OpenAI-backed run.
+
+Validated path:
+
+- fresh `ubuntu:24.04`
+- install `curl` and `ca-certificates`
+- download the public GitHub Release tarball
+- put `OPENAI_API_KEY` in `./.env`
+- run `./kelvin`
+
+Prerequisites:
+
+- `curl`
+- `tar`
+- `awk`
+- `ca-certificates` on minimal Linux images
+
+Example for Linux arm64:
+
+```bash
+apt-get update && apt-get install -y curl ca-certificates
+curl -fsSL -O https://github.com/AgenticHighway/kelvinclaw/releases/download/v0.1.1/kelvinclaw-0.1.1-linux-arm64.tar.gz
+curl -fsSL -O https://github.com/AgenticHighway/kelvinclaw/releases/download/v0.1.1/kelvinclaw-0.1.1-linux-arm64.tar.gz.sha256
+sha256sum -c kelvinclaw-0.1.1-linux-arm64.tar.gz.sha256
+tar -xzf kelvinclaw-0.1.1-linux-arm64.tar.gz
+cd kelvinclaw-0.1.1-linux-arm64
+printf 'OPENAI_API_KEY=%s\n' '<your_key>' > .env
+./kelvin
+```
+
+Example for Linux x86_64:
+
+```bash
+apt-get update && apt-get install -y curl ca-certificates
+curl -fsSL -O https://github.com/AgenticHighway/kelvinclaw/releases/download/v0.1.1/kelvinclaw-0.1.1-linux-x86_64.tar.gz
+curl -fsSL -O https://github.com/AgenticHighway/kelvinclaw/releases/download/v0.1.1/kelvinclaw-0.1.1-linux-x86_64.tar.gz.sha256
+sha256sum -c kelvinclaw-0.1.1-linux-x86_64.tar.gz.sha256
+tar -xzf kelvinclaw-0.1.1-linux-x86_64.tar.gz
+cd kelvinclaw-0.1.1-linux-x86_64
+printf 'OPENAI_API_KEY=%s\n' '<your_key>' > .env
+./kelvin
+```
+
+Expected result:
+
+- `./kelvin` fetches the official trust policy
+- `kelvin.cli@0.1.1` installs automatically
+- `kelvin.openai@0.1.1` installs automatically when `OPENAI_API_KEY` is available
+- the no-args run completes with `provider=openai` and `model=gpt-4.1-mini`
+
+Other supported key inputs:
+
+- export `OPENAI_API_KEY` in the shell before running `./kelvin`
+- put `OPENAI_API_KEY=...` in `./.env.local`
+- put `OPENAI_API_KEY=...` in `~/.kelvinclaw/.env` or `~/.kelvinclaw/.env.local`
+- in an interactive terminal, `./kelvin` prompts once if no key is configured
+
 ## Canonical Quick Start (Daily Driver MVP)
 
 Local profile (gateway + memory controller + SDK runtime):


### PR DESCRIPTION
## Summary
- add a release-first onboarding section to docs/GETTING_STARTED.md
- document the validated public GitHub Release flow for Linux arm64 and x86_64
- show the .env-based OpenAI key path and the expected first-run behavior

## Validation
- reviewed the section against the validated Docker onboarding flow for v0.1.1
- confirmed the documented commands match the public GitHub Release asset names