### PR TITLE
Optimize workflows for Blacksmith

### DIFF
--- a/.github/workflows/manual-verify.yml
+++ b/.github/workflows/manual-verify.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b
         with:
           persist-credentials: false
 
@@ -40,6 +40,9 @@ jobs:
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
           toolchain: ${{ inputs.rust_toolchain }}
+
+      - name: Restore Rust cache
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5
 
       - name: Install Rust components
         run: rustup component add rustfmt clippy

--- a/.github/workflows/memory-kms-smoke.yml
+++ b/.github/workflows/memory-kms-smoke.yml
@@ -23,7 +23,7 @@ jobs:
       KELVIN_TEST_AWS_KMS_MEMORY_REGION: us-east-1
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b
         with:
           persist-credentials: false
 
@@ -37,6 +37,9 @@ jobs:
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
           toolchain: stable
+
+      - name: Restore Rust cache
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5
 
       - name: Run live KMS memory signer smoke
         run: cargo test -p kelvin-memory-client rpc_memory_manager_kms_signing_roundtrip -- --nocapture

--- a/.github/workflows/plugin-abi-compat.yml
+++ b/.github/workflows/plugin-abi-compat.yml
@@ -20,7 +20,7 @@ jobs:
           - kelvin.anthropic
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b
         with:
           persist-credentials: false
 
@@ -28,6 +28,9 @@ jobs:
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
           toolchain: stable
+
+      - name: Restore Rust cache
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5
 
       - name: Install Rust components
         run: rustup component add rustfmt clippy

--- a/.github/workflows/release-linux-executables.yml
+++ b/.github/workflows/release-linux-executables.yml
@@ -28,7 +28,7 @@ jobs:
             target: aarch64-unknown-linux-gnu
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b
         with:
           persist-credentials: false
 
@@ -36,6 +36,9 @@ jobs:
         uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
         with:
           toolchain: stable
+
+      - name: Restore Rust cache
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5
 
       - name: Build and package Linux executables
         run: scripts/package-linux-release.sh --target "${{ matrix.target }}"


### PR DESCRIPTION
## Summary
- switch Blacksmith-run jobs to use useblacksmith/checkout for checkout caching
- add useblacksmith/rust-cache to Rust-heavy workflows

## Why
- these workflows already run on Blacksmith runners, so checkout caching and Rust dependency caching are the applicable Blacksmith features to enable now
- Docker build/container/pull caching does not apply to the current kelvinclaw workflows because they do not build Docker images or run service-container heavy jobs

## Validation
- parsed all workflow YAML locally