### PR TITLE
Use upstream cache actions on Blacksmith

### DIFF
--- a/.github/workflows/manual-verify.yml
+++ b/.github/workflows/manual-verify.yml
@@ -42,7 +42,7 @@ jobs:
           toolchain: ${{ inputs.rust_toolchain }}
 
       - name: Restore Rust cache
-        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5
+        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1
 
       - name: Install Rust components
         run: rustup component add rustfmt clippy

--- a/.github/workflows/memory-kms-smoke.yml
+++ b/.github/workflows/memory-kms-smoke.yml
@@ -39,7 +39,7 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5
+        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1
 
       - name: Run live KMS memory signer smoke
         run: cargo test -p kelvin-memory-client rpc_memory_manager_kms_signing_roundtrip -- --nocapture

--- a/.github/workflows/plugin-abi-compat.yml
+++ b/.github/workflows/plugin-abi-compat.yml
@@ -30,7 +30,7 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5
+        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1
 
       - name: Install Rust components
         run: rustup component add rustfmt clippy

--- a/.github/workflows/release-linux-executables.yml
+++ b/.github/workflows/release-linux-executables.yml
@@ -38,7 +38,7 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5
+        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1
 
       - name: Build and package Linux executables
         run: scripts/package-linux-release.sh --target "${{ matrix.target }}"


### PR DESCRIPTION
## Summary
- keep useblacksmith/checkout for checkout caching
- switch Rust caching to upstream Swatinem/rust-cache

## Why
- Blacksmith checkout caching requires useblacksmith/checkout
- Blacksmith dependency caching docs recommend upstream cache actions because they transparently use the Blacksmith cache backend

## Validation
- parsed all workflow YAML locally