### PR TITLE
Update workflow pin to Node 24-compatible AWS action

### DIFF
--- a/.github/workflows/memory-kms-smoke.yml
+++ b/.github/workflows/memory-kms-smoke.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7
         with:
           role-to-assume: ${{ env.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
## Summary
- update the AWS credentials action pin to the current Node 24-compatible release
- keep the existing Blacksmith runner and checkout configuration unchanged

## Testing
- parsed workflow YAML locally
