### PR TITLE
Update rust-cache pins to Node 24-compatible release

### DIFF
--- a/.github/workflows/manual-verify.yml
+++ b/.github/workflows/manual-verify.yml
@@ -42,7 +42,7 @@ jobs:
           toolchain: ${{ inputs.rust_toolchain }}
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Install Rust components
         run: rustup component add rustfmt clippy

--- a/.github/workflows/memory-kms-smoke.yml
+++ b/.github/workflows/memory-kms-smoke.yml
@@ -39,7 +39,7 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Run live KMS memory signer smoke
         run: cargo test -p kelvin-memory-client rpc_memory_manager_kms_signing_roundtrip -- --nocapture

--- a/.github/workflows/plugin-abi-compat.yml
+++ b/.github/workflows/plugin-abi-compat.yml
@@ -30,7 +30,7 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Install Rust components
         run: rustup component add rustfmt clippy

--- a/.github/workflows/release-linux-executables.yml
+++ b/.github/workflows/release-linux-executables.yml
@@ -38,7 +38,7 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Build and package Linux executables
         run: scripts/package-linux-release.sh --target "${{ matrix.target }}"


### PR DESCRIPTION
## Summary
- update all kelvinclaw rust-cache pins to the current Node 24-compatible release
- keep the existing Blacksmith runner and checkout configuration unchanged

## Testing
- parsed workflow YAML locally
