### PR TITLE
Fix macOS release runner labels

### DIFF
--- a/.github/workflows/release-executables.yml
+++ b/.github/workflows/release-executables.yml
@@ -66,9 +66,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-13
+          - runner: macos-15-intel
             target: x86_64-apple-darwin
-          - runner: macos-14
+          - runner: macos-15
             target: aarch64-apple-darwin
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- switch the macOS x64 release lane to the supported  runner
- move the macOS arm lane to  for consistency

## Testing
- observed the previous workflow failure on 
