### PR TITLE
Fix Windows packager param block position

### DIFF
--- a/scripts/package-windows-release.ps1
+++ b/scripts/package-windows-release.ps1
@@ -1,5 +1,3 @@
-$ErrorActionPreference = "Stop"
-
 param(
     [Parameter(Mandatory = $true)]
     [string]$Target,
@@ -7,6 +5,8 @@ param(
     [string]$TargetDir = "",
     [string]$Version = ""
 )
+
+$ErrorActionPreference = "Stop"
 
 $RootDir = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
 $OutputDir = if ($OutputDir) { $OutputDir } else { Join-Path $PSScriptRoot "..\\dist\\releases" }


### PR DESCRIPTION
Summary:
- move the PowerShell param block to the top of the Windows packager script
- keep the rest of the Windows packaging logic unchanged

Testing:
- observed the live Windows parser failure on the release workflow
