### PR TITLE
Fix release artifact versioning

### DIFF
--- a/.github/workflows/release-executables.yml
+++ b/.github/workflows/release-executables.yml
@@ -2,6 +2,11 @@ name: Release Executables
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: Optional release version label (for example 0.1.3 or v0.1.3)
+        required: false
+        type: string
   push:
     tags:
       - "v*"
@@ -17,8 +22,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  resolve-version:
+    name: Resolve Release Version
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b
+        with:
+          persist-credentials: false
+
+      - name: Resolve version label
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+          raw_version="${{ github.event.inputs.version }}"
+          if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
+            raw_version="${GITHUB_REF_NAME}"
+          fi
+          if [[ -z "${raw_version}" ]]; then
+            raw_version="$(awk -F'"' '/^version = "/ {print $2; exit}' Cargo.toml)"
+          fi
+          normalized_version="${raw_version#v}"
+          if [[ ! "${normalized_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid release version: ${raw_version}" >&2
+            exit 1
+          fi
+          echo "version=${normalized_version}" >> "${GITHUB_OUTPUT}"
+
   build-linux:
     name: Build Linux (${{ matrix.target }})
+    needs: resolve-version
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     strategy:
@@ -44,7 +80,7 @@ jobs:
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
 
       - name: Build and package Linux release artifacts
-        run: scripts/package-linux-release.sh --target "${{ matrix.target }}"
+        run: scripts/package-linux-release.sh --target "${{ matrix.target }}" --version "${{ needs.resolve-version.outputs.version }}"
 
       - name: Upload Linux release artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -60,6 +96,7 @@ jobs:
 
   build-macos:
     name: Build macOS (${{ matrix.target }})
+    needs: resolve-version
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     strategy:
@@ -86,7 +123,7 @@ jobs:
 
       - name: Build and package macOS release artifacts
         shell: bash
-        run: scripts/package-macos-release.sh --target "${{ matrix.target }}"
+        run: scripts/package-macos-release.sh --target "${{ matrix.target }}" --version "${{ needs.resolve-version.outputs.version }}"
 
       - name: Upload macOS release artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -100,6 +137,7 @@ jobs:
 
   build-windows:
     name: Build Windows (${{ matrix.target }})
+    needs: resolve-version
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     strategy:
@@ -124,7 +162,7 @@ jobs:
 
       - name: Build and package Windows release artifacts
         shell: pwsh
-        run: scripts/package-windows-release.ps1 -Target "${{ matrix.target }}"
+        run: scripts/package-windows-release.ps1 -Target "${{ matrix.target }}" -Version "${{ needs.resolve-version.outputs.version }}"
 
       - name: Upload Windows release artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -140,6 +178,7 @@ jobs:
     name: Publish GitHub Release
     if: ${{ github.event_name == 'push' }}
     needs:
+      - resolve-version
       - build-linux
       - build-macos
       - build-windows

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1828,7 +1828,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-brain"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-core"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "semver",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-gateway"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "axum",
  "ed25519-dalek",
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-host"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "kelvin-core",
  "kelvin-sdk",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-memory"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "kelvin-core",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-memory-api"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-memory-client"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -1943,7 +1943,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-memory-controller"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "jsonwebtoken",
@@ -1963,14 +1963,14 @@ dependencies = [
 
 [[package]]
 name = "kelvin-memory-module-sdk"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "kelvin-registry"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "axum",
  "kelvin-core",
@@ -1983,7 +1983,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-sdk"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-wasm"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "kelvin-core",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 authors = ["KelvinClaw Contributors"]


### PR DESCRIPTION
## Summary
- bump the workspace version to 0.1.3
- resolve release version labels from the tag or manual input once per workflow run
- pass the resolved version into every release packager so asset names match the release

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-executables.yml"); puts "workflow ok"'
- docker run --rm -v /Users/will/Documents/Github/agentichighway/kelvinclaw:/repo -w /repo rust:1-bookworm bash -lc 'apt-get update >/dev/null && apt-get install -y jq >/dev/null && ./scripts/package-linux-release.sh --target aarch64-unknown-linux-gnu --version 0.1.3'