### PR TITLE
Use Blacksmith cache on Blacksmith jobs

### DIFF
--- a/.github/workflows/manual-verify.yml
+++ b/.github/workflows/manual-verify.yml
@@ -42,7 +42,16 @@ jobs:
           toolchain: ${{ inputs.rust_toolchain }}
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        uses: useblacksmith/cache@71c7c918062ba3861252d84b07fe5ab2a6b467a6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: rust-${{ github.workflow }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rust_toolchain }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'apps/**/Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            rust-${{ github.workflow }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rust_toolchain }}-
+            rust-${{ github.workflow }}-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install Rust components
         run: rustup component add rustfmt clippy

--- a/.github/workflows/memory-kms-smoke.yml
+++ b/.github/workflows/memory-kms-smoke.yml
@@ -39,7 +39,15 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        uses: useblacksmith/cache@71c7c918062ba3861252d84b07fe5ab2a6b467a6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: rust-${{ github.workflow }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'apps/**/Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            rust-${{ github.workflow }}-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Run live KMS memory signer smoke
         run: cargo test -p kelvin-memory-client rpc_memory_manager_kms_signing_roundtrip -- --nocapture

--- a/.github/workflows/plugin-abi-compat.yml
+++ b/.github/workflows/plugin-abi-compat.yml
@@ -30,7 +30,16 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        uses: useblacksmith/cache@71c7c918062ba3861252d84b07fe5ab2a6b467a6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: rust-${{ github.workflow }}-${{ runner.os }}-${{ runner.arch }}-${{ matrix.plugin }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'apps/**/Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            rust-${{ github.workflow }}-${{ runner.os }}-${{ runner.arch }}-${{ matrix.plugin }}-
+            rust-${{ github.workflow }}-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Install Rust components
         run: rustup component add rustfmt clippy

--- a/.github/workflows/release-executables.yml
+++ b/.github/workflows/release-executables.yml
@@ -46,7 +46,16 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        uses: useblacksmith/cache@71c7c918062ba3861252d84b07fe5ab2a6b467a6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/releases
+          key: release-rust-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'apps/**/Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            release-rust-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-
+            release-rust-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Resolve release version
         shell: bash
@@ -159,7 +168,16 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        uses: useblacksmith/cache@71c7c918062ba3861252d84b07fe5ab2a6b467a6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/releases
+          key: release-rust-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'apps/**/Cargo.toml', 'crates/**/Cargo.toml') }}
+          restore-keys: |
+            release-rust-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-
+            release-rust-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Resolve release version
         shell: pwsh


### PR DESCRIPTION
## Summary
- replace rust-cache with explicit useblacksmith/cache on Blacksmith-backed workflows
- keep macOS on the GitHub-hosted path
- align the release workflow and the other Blacksmith jobs with the intended cache provider

## Validation
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts f }'
- git diff --check