### PR TITLE
Use Blacksmith rust cache

### DIFF
--- a/.github/workflows/manual-verify.yml
+++ b/.github/workflows/manual-verify.yml
@@ -42,16 +42,10 @@ jobs:
           toolchain: ${{ inputs.rust_toolchain }}
 
       - name: Restore Rust cache
-        uses: useblacksmith/cache@71c7c918062ba3861252d84b07fe5ab2a6b467a6
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: rust-${{ github.workflow }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rust_toolchain }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'apps/**/Cargo.toml', 'crates/**/Cargo.toml') }}
-          restore-keys: |
-            rust-${{ github.workflow }}-${{ runner.os }}-${{ runner.arch }}-${{ inputs.rust_toolchain }}-
-            rust-${{ github.workflow }}-${{ runner.os }}-${{ runner.arch }}-
+          workspaces: . -> target
+          key: manual-verify-${{ inputs.rust_toolchain }}
 
       - name: Install Rust components
         run: rustup component add rustfmt clippy

--- a/.github/workflows/memory-kms-smoke.yml
+++ b/.github/workflows/memory-kms-smoke.yml
@@ -39,15 +39,10 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: useblacksmith/cache@71c7c918062ba3861252d84b07fe5ab2a6b467a6
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: rust-${{ github.workflow }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'apps/**/Cargo.toml', 'crates/**/Cargo.toml') }}
-          restore-keys: |
-            rust-${{ github.workflow }}-${{ runner.os }}-${{ runner.arch }}-
+          workspaces: . -> target
+          key: memory-kms-smoke
 
       - name: Run live KMS memory signer smoke
         run: cargo test -p kelvin-memory-client rpc_memory_manager_kms_signing_roundtrip -- --nocapture

--- a/.github/workflows/plugin-abi-compat.yml
+++ b/.github/workflows/plugin-abi-compat.yml
@@ -30,16 +30,10 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: useblacksmith/cache@71c7c918062ba3861252d84b07fe5ab2a6b467a6
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: rust-${{ github.workflow }}-${{ runner.os }}-${{ runner.arch }}-${{ matrix.plugin }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'apps/**/Cargo.toml', 'crates/**/Cargo.toml') }}
-          restore-keys: |
-            rust-${{ github.workflow }}-${{ runner.os }}-${{ runner.arch }}-${{ matrix.plugin }}-
-            rust-${{ github.workflow }}-${{ runner.os }}-${{ runner.arch }}-
+          workspaces: . -> target
+          key: plugin-abi-${{ matrix.plugin }}
 
       - name: Install Rust components
         run: rustup component add rustfmt clippy

--- a/.github/workflows/release-executables.yml
+++ b/.github/workflows/release-executables.yml
@@ -46,16 +46,10 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: useblacksmith/cache@71c7c918062ba3861252d84b07fe5ab2a6b467a6
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target/releases
-          key: release-rust-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'apps/**/Cargo.toml', 'crates/**/Cargo.toml') }}
-          restore-keys: |
-            release-rust-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-
-            release-rust-${{ runner.os }}-${{ runner.arch }}-
+          workspaces: . -> target/releases
+          key: release-${{ matrix.target }}
 
       - name: Resolve release version
         shell: bash
@@ -168,16 +162,10 @@ jobs:
           toolchain: stable
 
       - name: Restore Rust cache
-        uses: useblacksmith/cache@71c7c918062ba3861252d84b07fe5ab2a6b467a6
+        uses: useblacksmith/rust-cache@f53e7f127245d2a269b3d90879ccf259876842d5
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target/releases
-          key: release-rust-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'apps/**/Cargo.toml', 'crates/**/Cargo.toml') }}
-          restore-keys: |
-            release-rust-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target }}-
-            release-rust-${{ runner.os }}-${{ runner.arch }}-
+          workspaces: . -> target/releases
+          key: release-${{ matrix.target }}
 
       - name: Resolve release version
         shell: pwsh


### PR DESCRIPTION
## Summary
- switch Blacksmith-backed workflows to useblacksmith/rust-cache
- keep macOS on the GitHub-hosted path with the existing cache action
- align the release and verification workflows with Blacksmith's Rust cache guidance

## Validation
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f); puts f }'
- git diff --check