### PR TITLE
Harden plugin authoring and release workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,6 +541,7 @@ export PATH="$PWD/scripts:$PATH"
 kelvin plugin new --id acme.echo --name "Acme Echo" --runtime wasm_tool_v1
 kelvin plugin test --manifest ./plugin-acme.echo/plugin.json
 kelvin plugin pack --manifest ./plugin-acme.echo/plugin.json
+kelvin plugin install --package ./plugin-acme.echo/dist/acme.echo-0.1.0.tar.gz
 kelvin plugin verify --package ./plugin-acme.echo/dist/acme.echo-0.1.0.tar.gz
 ```
 
@@ -553,7 +554,9 @@ cd ./plugin-acme.anthropic
 ./build.sh
 kelvin plugin test --manifest ./plugin.json
 kelvin plugin pack --manifest ./plugin.json
+kelvin plugin install --package ./dist/acme.anthropic-0.1.0.tar.gz
 kelvin plugin verify --package ./dist/acme.anthropic-0.1.0.tar.gz
+kelvin plugin smoke --manifest ./plugin.json
 ```
 
 Community/local plugins can stay `unsigned_local`. Kelvin warns on install, but

--- a/docker/Dockerfile.plugin-author
+++ b/docker/Dockerfile.plugin-author
@@ -16,8 +16,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
       build-essential \
       ca-certificates \
       curl \
+      gcc-x86-64-linux-gnu \
       git \
       jq \
+      libc6-dev-amd64-cross \
       pkg-config \
       tar \
       xz-utils \

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -235,6 +235,7 @@ Expected result:
 - Sample WASM skill builds successfully.
 - WASM runner executes the module under sandbox policy.
 - Plugin author commands scaffold and validate plugin package structure without touching root crates.
+- `kelvin plugin install` and `kelvin plugin smoke` cover the local package-install and model-runtime smoke path without requiring host flag memorization.
 - Model plugins can be scaffolded, built, packed, and locally installed through the same public SDK surface.
 
 ## Verify All Tracks

--- a/docs/build-a-model-plugin.md
+++ b/docs/build-a-model-plugin.md
@@ -43,7 +43,9 @@ cd ./plugin-acme.anthropic
 ./build.sh
 ../scripts/kelvin-plugin.sh test --manifest ./plugin.json
 ../scripts/kelvin-plugin.sh pack --manifest ./plugin.json
+../scripts/kelvin-plugin.sh install --package ./dist/acme.anthropic-0.1.0.tar.gz
 ../scripts/kelvin-plugin.sh verify --package ./dist/acme.anthropic-0.1.0.tar.gz
+../scripts/kelvin-plugin.sh smoke --manifest ./plugin.json
 ```
 
 The same flow in Docker:
@@ -59,7 +61,9 @@ scripts/plugin-author-docker.sh -- bash -lc '
   ./build.sh
   ../scripts/kelvin-plugin.sh test --manifest ./plugin.json
   ../scripts/kelvin-plugin.sh pack --manifest ./plugin.json
+  ../scripts/kelvin-plugin.sh install --package ./dist/acme.anthropic-0.1.0.tar.gz
   ../scripts/kelvin-plugin.sh verify --package ./dist/acme.anthropic-0.1.0.tar.gz
+  ../scripts/kelvin-plugin.sh smoke --manifest ./plugin.json
 '
 ```
 
@@ -103,22 +107,12 @@ scripts/kelvin-plugin.sh new \
 Local development plugins can stay `unsigned_local`:
 
 ```bash
-scripts/plugin-install.sh --package ./dist/acme.anthropic-0.1.0.tar.gz
+scripts/kelvin-plugin.sh install --package ./dist/acme.anthropic-0.1.0.tar.gz
+scripts/kelvin-plugin.sh smoke --manifest ./plugin.json
 ```
 
 Kelvin prints a warning for `unsigned_local`, but still installs the package so
 you can develop without access to the first-party signing platform.
-
-Run Kelvin with the plugin:
-
-```bash
-KELVIN_PLUGIN_HOME="${HOME}/.kelvinclaw/plugins" \
-KELVIN_TRUST_POLICY_PATH="${HOME}/.kelvinclaw/trusted_publishers.json" \
-cargo run -p kelvin-host -- \
-  --prompt "Summarize KelvinClaw in one sentence." \
-  --model-provider acme.anthropic \
-  --memory fallback
-```
 
 If you are validating in Docker, run the same commands through
 `scripts/plugin-author-docker.sh -- ...` so the repo path and caches stay

--- a/docs/kelvin-gap-analysis.md
+++ b/docs/kelvin-gap-analysis.md
@@ -211,3 +211,4 @@ Still open:
 ## Near-Term TODO (Execution Order)
 
 1. Automate publisher key rotation pipelines for hosted plugin/trust-policy distribution.
+2. Republish legacy first-party plugin tarballs that still emit `LIBARCHIVE.xattr.com.apple.provenance` warnings on Linux installs, then update the official release plugin pins to the cleaned package versions.

--- a/docs/plugin-author-kit.md
+++ b/docs/plugin-author-kit.md
@@ -17,13 +17,16 @@ Then use:
 kelvin plugin new
 kelvin plugin test
 kelvin plugin pack
+kelvin plugin install
+kelvin plugin index-install
 kelvin plugin verify
+kelvin plugin smoke
 ```
 
 Equivalent direct command:
 
 ```bash
-scripts/kelvin-plugin.sh <new|test|pack|verify> ...
+scripts/kelvin-plugin.sh <new|test|pack|install|index-install|verify|smoke> ...
 ```
 
 If you want a reproducible container instead of local Rust setup, use the
@@ -41,6 +44,7 @@ That is the supported Docker authoring path for plugin contributors.
 scripts/kelvin-plugin.sh new --id acme.echo --name "Acme Echo" --runtime wasm_tool_v1
 scripts/kelvin-plugin.sh test --manifest ./plugin-acme.echo/plugin.json
 scripts/kelvin-plugin.sh pack --manifest ./plugin-acme.echo/plugin.json
+scripts/kelvin-plugin.sh install --package ./plugin-acme.echo/dist/acme.echo-0.1.0.tar.gz
 scripts/kelvin-plugin.sh verify --package ./plugin-acme.echo/dist/acme.echo-0.1.0.tar.gz
 ```
 
@@ -83,6 +87,19 @@ scripts/plugin-author-docker.sh -- bash -lc 'cd examples/kelvin-anthropic-plugin
 
 Local/community development plugins can stay `unsigned_local`. Kelvin warns on
 install for that quality tier, but still allows the plugin to install.
+
+The supported local loop is:
+
+```bash
+scripts/kelvin-plugin.sh pack --manifest ./plugin.json
+scripts/kelvin-plugin.sh install --package ./dist/<id>-<version>.tar.gz
+scripts/kelvin-plugin.sh smoke --manifest ./plugin.json
+```
+
+`smoke` runs `./build.sh` when present, packs the plugin, installs it into a
+local plugin home, auto-installs `kelvin.cli` if needed, and then runs
+`kelvin-host`. If the model provider API key is missing, a clear
+`<ENV> is required` failure is treated as a successful no-key smoke.
 
 ```bash
 AWS_PROFILE=ah-willsarg-iam scripts/plugin-sign.sh \

--- a/scripts/kelvin
+++ b/scripts/kelvin
@@ -6,7 +6,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 usage() {
   cat <<'USAGE'
 Usage:
-  kelvin plugin <new|test|pack|verify> [args...]
+  kelvin plugin <new|test|pack|install|index-install|verify|smoke> [args...]
 
 Tip:
   export PATH="$PWD/scripts:$PATH"

--- a/scripts/kelvin-plugin.sh
+++ b/scripts/kelvin-plugin.sh
@@ -332,7 +332,11 @@ Commands:
   new       Create a new plugin package scaffold.
   test      Validate plugin manifest/layout and compatibility matrix.
   pack      Build a .tar.gz plugin package from manifest + payload.
+  install   Install a local plugin package into a plugin home.
+  index-install
+            Install a published plugin package from a plugin index.
   verify    Verify package integrity and policy-tier requirements.
+  smoke     Build, pack, install, and smoke-test a model plugin locally.
 
 Run with --help after any command for command-specific options.
 USAGE
@@ -362,10 +366,39 @@ Options:
   --model-name <name>       Model runtime: model name (default: protocol-family default)
   --entrypoint <path>       Relative wasm payload path (default: plugin.wasm)
   --quality-tier <tier>     unsigned_local|signed_community|signed_trusted (default: unsigned_local)
+  --force                   Overwrite an existing non-empty output directory
 
 `wasm_model_v1` scaffolds emit a structured `provider_profile` object, create a
 Rust guest source project, and run a local build, so `cargo`, `rustup`, and
 `jq` must be available.
+USAGE
+}
+
+install_usage() {
+  cat <<'USAGE'
+Usage: scripts/kelvin-plugin.sh install --package <plugin-package.tar.gz> [options]
+
+Options:
+  --package <path>          Plugin package tarball (.tar.gz)
+  --plugin-home <dir>       Install root (default: $KELVIN_PLUGIN_HOME or ~/.kelvinclaw/plugins)
+  --force                   Overwrite existing plugin version
+USAGE
+}
+
+index_install_usage() {
+  cat <<'USAGE'
+Usage: scripts/kelvin-plugin.sh index-install --plugin <id> [options]
+
+Options:
+  --plugin <id>             Plugin id from index
+  --version <version>       Specific version to install
+  --index-url <url>         Plugin index JSON URL
+  --registry-url <url>      Hosted registry base URL (uses /v1/index.json)
+  --plugin-home <dir>       Install root (default: $KELVIN_PLUGIN_HOME or ~/.kelvinclaw/plugins)
+  --trust-policy-path <path>
+                            Trust policy file to merge/update
+  --force                   Reinstall even if version exists
+  --min-quality-tier <tier> unsigned_local|signed_community|signed_trusted
 USAGE
 }
 
@@ -405,6 +438,32 @@ Options:
   --json                    Emit machine-readable output JSON
 
 Note: you must pass either --package or --manifest.
+USAGE
+}
+
+smoke_usage() {
+  cat <<'USAGE'
+Usage: scripts/kelvin-plugin.sh smoke --manifest <plugin.json> [options]
+
+Options:
+  --manifest <path>         Required path to plugin.json
+  --plugin-home <dir>       Plugin home to install into (default: temporary)
+  --trust-policy <path>     Trust policy path for CLI plugin install (default: temporary)
+  --workspace <dir>         Workspace directory for kelvin-host (default: manifest directory)
+  --prompt <text>           Prompt for the smoke run
+                            (default: Say hello in one sentence.)
+  --core-versions <csv>     Core versions matrix for validation (default: 0.1.0)
+  --skip-cli-install        Do not auto-install kelvin.cli from the plugin index
+  --no-build                Skip running ./build.sh before packing
+  --keep-temp               Keep temporary smoke artifacts on disk
+  --json                    Emit machine-readable result JSON
+
+Behavior:
+  - If build.sh exists next to plugin.json, Kelvin runs it unless --no-build is set.
+  - Kelvin packs and installs the plugin locally.
+  - Kelvin auto-installs kelvin.cli unless --skip-cli-install is set.
+  - If provider_profile.api_key_env is unset, a clear "<ENV> is required" failure
+    is treated as a successful no-key smoke.
 USAGE
 }
 
@@ -512,6 +571,7 @@ validate_manifest_and_layout() {
       (.provider_profile | type=="object") and
       (.provider_profile.id | type=="string" and length>0) and
       (.provider_profile.provider_name | type=="string" and length>0) and
+      ((.provider_name == null) or (.provider_name == .provider_profile.provider_name)) and
       (.provider_profile.protocol_family | type=="string" and (. == "openai_responses" or . == "openai_chat_completions" or . == "anthropic_messages")) and
       (.provider_profile.api_key_env | type=="string" and length>0) and
       (.provider_profile.base_url_env | type=="string" and length>0) and
@@ -620,6 +680,7 @@ cmd_new() {
   local provider_name="" provider_profile_id="" protocol_family="" api_key_env="" base_url_env=""
   local default_base_url="" endpoint_path="" auth_header="" auth_scheme="bearer"
   local model_name="default" entrypoint="plugin.wasm" quality_tier="unsigned_local"
+  local force="0"
   local -a allow_hosts=()
 
   while [[ $# -gt 0 ]]; do
@@ -643,6 +704,7 @@ cmd_new() {
       --model-name) model_name="${2:?missing value for --model-name}"; shift 2 ;;
       --entrypoint) entrypoint="${2:?missing value for --entrypoint}"; shift 2 ;;
       --quality-tier) quality_tier="${2:?missing value for --quality-tier}"; shift 2 ;;
+      --force) force="1"; shift ;;
       -h|--help) new_usage; exit 0 ;;
       *) echo "Unknown argument: $1" >&2; new_usage; exit 1 ;;
     esac
@@ -668,6 +730,21 @@ cmd_new() {
 
   if [[ -z "${out}" ]]; then
     out="./plugin-${id}"
+  fi
+  if [[ -e "${out}" && "${force}" != "1" ]]; then
+    if [[ -d "${out}" ]] && [[ -n "$(find "${out}" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null)" ]]; then
+      echo "Refusing to overwrite non-empty output directory: ${out}" >&2
+      echo "Re-run with --force if you want to replace it." >&2
+      exit 1
+    fi
+    if [[ ! -d "${out}" ]]; then
+      echo "Refusing to overwrite existing path: ${out}" >&2
+      echo "Re-run with --force if you want to replace it." >&2
+      exit 1
+    fi
+  fi
+  if [[ "${force}" == "1" && -e "${out}" ]]; then
+    rm -rf "${out}"
   fi
   mkdir -p "${out}/payload"
   if [[ -z "${tool_name}" ]]; then
@@ -832,6 +909,13 @@ Quick commands:
 \`\`\`bash
 scripts/kelvin-plugin.sh test --manifest "${out}/plugin.json"
 scripts/kelvin-plugin.sh pack --manifest "${out}/plugin.json"
+scripts/kelvin-plugin.sh install --package "${out}/dist/${id}-${version}.tar.gz"
+\`\`\`
+
+For a local runtime smoke:
+
+\`\`\`bash
+scripts/kelvin-plugin.sh smoke --manifest "${out}/plugin.json"
 \`\`\`
 
 For signing:
@@ -1004,6 +1088,206 @@ cmd_verify() {
   fi
 }
 
+cmd_install() {
+  local -a args=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --package|--plugin-home)
+        args+=("$1" "${2:?missing value for $1}")
+        shift 2
+        ;;
+      --force)
+        args+=("$1")
+        shift
+        ;;
+      -h|--help)
+        install_usage
+        exit 0
+        ;;
+      *)
+        echo "Unknown argument: $1" >&2
+        install_usage
+        exit 1
+        ;;
+    esac
+  done
+  exec "${ROOT_DIR}/scripts/plugin-install.sh" "${args[@]}"
+}
+
+cmd_index_install() {
+  local -a args=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --plugin|--version|--index-url|--registry-url|--plugin-home|--trust-policy-path|--min-quality-tier)
+        args+=("$1" "${2:?missing value for $1}")
+        shift 2
+        ;;
+      --force)
+        args+=("$1")
+        shift
+        ;;
+      -h|--help)
+        index_install_usage
+        exit 0
+        ;;
+      *)
+        echo "Unknown argument: $1" >&2
+        index_install_usage
+        exit 1
+        ;;
+    esac
+  done
+  exec "${ROOT_DIR}/scripts/plugin-index-install.sh" "${args[@]}"
+}
+
+cmd_smoke() {
+  local manifest="" plugin_home="" trust_policy="" workspace="" prompt="Say hello in one sentence."
+  local core_versions="${DEFAULT_CORE_VERSIONS}" skip_cli_install="0" no_build="0" keep_temp="0" json_output="0"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --manifest) manifest="${2:?missing value for --manifest}"; shift 2 ;;
+      --plugin-home) plugin_home="${2:?missing value for --plugin-home}"; shift 2 ;;
+      --trust-policy) trust_policy="${2:?missing value for --trust-policy}"; shift 2 ;;
+      --workspace) workspace="${2:?missing value for --workspace}"; shift 2 ;;
+      --prompt) prompt="${2:?missing value for --prompt}"; shift 2 ;;
+      --core-versions) core_versions="${2:?missing value for --core-versions}"; shift 2 ;;
+      --skip-cli-install) skip_cli_install="1"; shift ;;
+      --no-build) no_build="1"; shift ;;
+      --keep-temp) keep_temp="1"; shift ;;
+      --json) json_output="1"; shift ;;
+      -h|--help) smoke_usage; exit 0 ;;
+      *)
+        echo "Unknown argument: $1" >&2
+        smoke_usage
+        exit 1
+        ;;
+    esac
+  done
+
+  [[ -n "${manifest}" ]] || {
+    echo "--manifest is required" >&2
+    smoke_usage
+    exit 1
+  }
+
+  require_cmd cargo
+  if [[ "${skip_cli_install}" != "1" ]]; then
+    require_cmd curl
+  fi
+
+  validate_manifest_and_layout "${manifest}" "${core_versions}" "${DEFAULT_CORE_API_VERSION}" "0"
+
+  local manifest_dir runtime plugin_id api_key_env temp_dir package_path host_output
+  local keep_temp_value=""
+  manifest_dir="$(cd "$(dirname "${manifest}")" && pwd)"
+  runtime="$(jq -er '.runtime // "wasm_tool_v1"' "${manifest}")"
+  plugin_id="$(jq -er '.id' "${manifest}")"
+  if [[ "${runtime}" != "wasm_model_v1" ]]; then
+    echo "smoke currently supports wasm_model_v1 plugins only" >&2
+    exit 1
+  fi
+  api_key_env="$(jq -er '.provider_profile.api_key_env' "${manifest}")"
+
+  temp_dir="$(mktemp -d)"
+  keep_temp_value="${keep_temp}"
+  trap 'if [[ "'"${keep_temp_value}"'" != "1" ]]; then rm -rf "'"${temp_dir}"'"; fi' EXIT
+
+  if [[ -z "${plugin_home}" ]]; then
+    plugin_home="${temp_dir}/plugins"
+  fi
+  if [[ -z "${trust_policy}" ]]; then
+    trust_policy="${temp_dir}/trusted_publishers.json"
+  fi
+  if [[ -z "${workspace}" ]]; then
+    workspace="${manifest_dir}"
+  fi
+  package_path="${temp_dir}/$(jq -er '.id' "${manifest}")-$(jq -er '.version' "${manifest}").tar.gz"
+  host_output="${temp_dir}/kelvin-host.log"
+
+  mkdir -p "${plugin_home}" "$(dirname "${trust_policy}")"
+
+  if [[ "${no_build}" != "1" && -x "${manifest_dir}/build.sh" ]]; then
+    (
+      cd "${manifest_dir}"
+      ./build.sh >/dev/null
+    )
+  fi
+
+  cmd_pack --manifest "${manifest}" --output "${package_path}" --core-versions "${core_versions}" >/dev/null
+  "${ROOT_DIR}/scripts/plugin-install.sh" --package "${package_path}" --plugin-home "${plugin_home}" --force >/dev/null
+
+  if [[ "${skip_cli_install}" != "1" && ! -d "${plugin_home}/kelvin.cli/current" ]]; then
+    "${ROOT_DIR}/scripts/plugin-index-install.sh" \
+      --plugin kelvin.cli \
+      --plugin-home "${plugin_home}" \
+      --trust-policy-path "${trust_policy}" \
+      --min-quality-tier signed_trusted \
+      --force >/dev/null
+  fi
+
+  set +e
+  (
+    cd "${ROOT_DIR}"
+    KELVIN_PLUGIN_HOME="${plugin_home}" \
+    KELVIN_TRUST_POLICY_PATH="${trust_policy}" \
+    cargo run -q -p kelvin-host -- \
+      --prompt "${prompt}" \
+      --workspace "${workspace}" \
+      --memory fallback \
+      --model-provider "${plugin_id}"
+  ) >"${host_output}" 2>&1
+  local status=$?
+  set -e
+
+  local key_present="0"
+  [[ -n "${!api_key_env:-}" ]] && key_present="1"
+
+  if [[ "${key_present}" == "0" ]]; then
+    if grep -Fq "${api_key_env} is required" "${host_output}"; then
+      if [[ "${json_output}" == "1" ]]; then
+        jq -cn \
+          --arg plugin_id "${plugin_id}" \
+          --arg api_key_env "${api_key_env}" \
+          --arg plugin_home "${plugin_home}" \
+          --arg trust_policy "${trust_policy}" \
+          --arg workspace "${workspace}" \
+          '{"ok":true,"mode":"missing_key_expected","plugin_id":$plugin_id,"api_key_env":$api_key_env,"plugin_home":$plugin_home,"trust_policy":$trust_policy,"workspace":$workspace}'
+      else
+        echo "[kelvin-plugin] smoke ok (${api_key_env} missing path)"
+        echo "  plugin:      ${plugin_id}"
+        echo "  plugin_home: ${plugin_home}"
+        echo "  trust:       ${trust_policy}"
+      fi
+      return 0
+    fi
+    cat "${host_output}" >&2
+    echo "smoke failed: expected a clear '${api_key_env} is required' message when ${api_key_env} is unset" >&2
+    exit 1
+  fi
+
+  if [[ "${status}" -ne 0 ]]; then
+    cat "${host_output}" >&2
+    echo "smoke failed: kelvin-host exited with status ${status}" >&2
+    exit 1
+  fi
+
+  if [[ "${json_output}" == "1" ]]; then
+    jq -cn \
+      --arg plugin_id "${plugin_id}" \
+      --arg api_key_env "${api_key_env}" \
+      --arg plugin_home "${plugin_home}" \
+      --arg trust_policy "${trust_policy}" \
+      --arg workspace "${workspace}" \
+      '{"ok":true,"mode":"live_key_success","plugin_id":$plugin_id,"api_key_env":$api_key_env,"plugin_home":$plugin_home,"trust_policy":$trust_policy,"workspace":$workspace}'
+  else
+    echo "[kelvin-plugin] smoke ok (${api_key_env} present path)"
+    echo "  plugin:      ${plugin_id}"
+    echo "  plugin_home: ${plugin_home}"
+    echo "  trust:       ${trust_policy}"
+  fi
+}
+
 main() {
   require_cmd jq
   require_cmd tar
@@ -1018,7 +1302,10 @@ main() {
     new) cmd_new "$@" ;;
     test) cmd_test "$@" ;;
     pack) cmd_pack "$@" ;;
+    install) cmd_install "$@" ;;
+    index-install) cmd_index_install "$@" ;;
     verify) cmd_verify "$@" ;;
+    smoke) cmd_smoke "$@" ;;
     -h|--help) usage ;;
     *) echo "Unknown command: ${command}" >&2; usage; exit 1 ;;
   esac

--- a/scripts/package-unix-release.sh
+++ b/scripts/package-unix-release.sh
@@ -7,6 +7,7 @@ TARGET=""
 VERSION=""
 TARGET_DIR="${ROOT_DIR}/target/releases"
 EMIT_DEB="false"
+SKIP_SMOKE_TEST="false"
 
 # shellcheck source=scripts/lib/rust-toolchain-path.sh
 source "${ROOT_DIR}/scripts/lib/rust-toolchain-path.sh"
@@ -25,6 +26,7 @@ Options:
   --target-dir <path>      Cargo target dir (default: ./target/releases)
   --version <semver>       Override version label (default: workspace version)
   --emit-deb               Also build a .deb package for Linux targets
+  --skip-smoke-test        Skip archive binary smoke tests
   -h, --help               Show help
 USAGE
 }
@@ -35,6 +37,36 @@ require_cmd() {
     echo "Missing required command: ${name}" >&2
     exit 1
   fi
+}
+
+build_release_binaries() {
+  local target="$1"
+  local target_dir="$2"
+  CARGO_TARGET_DIR="${target_dir}" cargo build \
+    --locked \
+    --release \
+    --target "${target}" \
+    -p kelvin-host \
+    -p kelvin-gateway \
+    -p kelvin-registry \
+    -p kelvin-memory-controller \
+    --features kelvin-gateway/memory_rpc
+}
+
+target_architecture() {
+  case "$1" in
+    x86_64-unknown-linux-gnu|x86_64-apple-darwin) printf '%s\n' 'x86_64' ;;
+    aarch64-unknown-linux-gnu|aarch64-apple-darwin) printf '%s\n' 'aarch64' ;;
+    *) echo "Unsupported target triple: $1" >&2; exit 1 ;;
+  esac
+}
+
+host_architecture() {
+  case "$(uname -m)" in
+    x86_64|amd64) printf '%s\n' 'x86_64' ;;
+    arm64|aarch64) printf '%s\n' 'aarch64' ;;
+    *) uname -m ;;
+  esac
 }
 
 sha256_file() {
@@ -189,6 +221,10 @@ while [[ $# -gt 0 ]]; do
       EMIT_DEB="true"
       shift
       ;;
+    --skip-smoke-test)
+      SKIP_SMOKE_TEST="true"
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -233,10 +269,7 @@ mkdir -p "${OUTPUT_DIR}" "${STAGE_ROOT}/bin" "${STAGE_ROOT}/share"
 
 rustup target add "${TARGET}" >/dev/null
 
-CARGO_TARGET_DIR="${TARGET_DIR}" cargo build --locked --release --target "${TARGET}" -p kelvin-host
-CARGO_TARGET_DIR="${TARGET_DIR}" cargo build --locked --release --target "${TARGET}" -p kelvin-gateway --features memory_rpc
-CARGO_TARGET_DIR="${TARGET_DIR}" cargo build --locked --release --target "${TARGET}" -p kelvin-registry
-CARGO_TARGET_DIR="${TARGET_DIR}" cargo build --locked --release --target "${TARGET}" -p kelvin-memory-controller
+build_release_binaries "${TARGET}" "${TARGET_DIR}"
 
 cp "${TARGET_DIR}/${TARGET}/release/kelvin-host" "${STAGE_ROOT}/bin/"
 cp "${TARGET_DIR}/${TARGET}/release/kelvin-gateway" "${STAGE_ROOT}/bin/"
@@ -263,7 +296,13 @@ EOF
 rm -f "${ARCHIVE_PATH}" "${CHECKSUM_PATH}"
 create_tar_gz "${ARCHIVE_PATH}" "${STAGE_PARENT}" "${ARCHIVE_ROOT}"
 printf '%s  %s\n' "$(sha256_file "${ARCHIVE_PATH}")" "$(basename "${ARCHIVE_PATH}")" > "${CHECKSUM_PATH}"
-smoke_test_archive "${ARCHIVE_PATH}" "${ARCHIVE_ROOT}" "" "kelvin"
+if [[ "${SKIP_SMOKE_TEST}" == "true" ]]; then
+  echo "Skipping archive smoke test (--skip-smoke-test)"
+elif [[ "$(target_architecture "${TARGET}")" != "$(host_architecture)" ]]; then
+  echo "Skipping archive smoke test for cross-arch target ${TARGET} on host $(host_architecture)"
+else
+  smoke_test_archive "${ARCHIVE_PATH}" "${ARCHIVE_ROOT}" "" "kelvin"
+fi
 
 if [[ "${EMIT_DEB}" == "true" ]]; then
   create_deb_package "${STAGE_ROOT}" "${VERSION}" "${TARGET}" "${OUTPUT_DIR}"

--- a/scripts/package-windows-release.ps1
+++ b/scripts/package-windows-release.ps1
@@ -41,6 +41,16 @@ function Sha256-File([string]$Path) {
     return (Get-FileHash -Algorithm SHA256 -Path $Path).Hash.ToLowerInvariant()
 }
 
+function Build-ReleaseBinaries([string]$Triple, [string]$TargetDirPath) {
+    $env:CARGO_TARGET_DIR = $TargetDirPath
+    cargo build --locked --release --target $Triple `
+      -p kelvin-host `
+      -p kelvin-gateway `
+      -p kelvin-registry `
+      -p kelvin-memory-controller `
+      --features kelvin-gateway/memory_rpc
+}
+
 function Smoke-TestZip([string]$ZipPath, [string]$RootName) {
     $WorkDir = Join-Path ([System.IO.Path]::GetTempPath()) ([System.Guid]::NewGuid().ToString())
     New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
@@ -76,11 +86,7 @@ try {
 
     rustup target add $Target | Out-Null
 
-    $env:CARGO_TARGET_DIR = $TargetDir
-    cargo build --locked --release --target $Target -p kelvin-host
-    cargo build --locked --release --target $Target -p kelvin-gateway --features memory_rpc
-    cargo build --locked --release --target $Target -p kelvin-registry
-    cargo build --locked --release --target $Target -p kelvin-memory-controller
+    Build-ReleaseBinaries -Triple $Target -TargetDirPath $TargetDir
 
     Copy-Item (Join-Path $TargetDir "$Target\\release\\kelvin-host.exe") (Join-Path $StageRoot "bin\\")
     Copy-Item (Join-Path $TargetDir "$Target\\release\\kelvin-gateway.exe") (Join-Path $StageRoot "bin\\")

--- a/scripts/test-plugin-author-kit.sh
+++ b/scripts/test-plugin-author-kit.sh
@@ -42,14 +42,19 @@ SHA="$(sha256_file ./plugin-acme/payload/plugin.wasm)"
 jq --arg sha "${SHA}" '.entrypoint_sha256 = $sha' ./plugin-acme/plugin.json > ./plugin-acme/plugin.json.tmp
 mv ./plugin-acme/plugin.json.tmp ./plugin-acme/plugin.json
 
+"${PLUGIN_CLI}" install --help >/dev/null
+"${PLUGIN_CLI}" index-install --help >/dev/null
+"${PLUGIN_CLI}" smoke --help >/dev/null
 "${PLUGIN_CLI}" test --manifest ./plugin-acme/plugin.json --core-versions "0.1.0,0.2.0"
 "${PLUGIN_CLI}" pack --manifest ./plugin-acme/plugin.json
 "${PLUGIN_CLI}" verify --package ./plugin-acme/dist/acme.echo-0.1.0.tar.gz
+"${PLUGIN_CLI}" install --package ./plugin-acme/dist/acme.echo-0.1.0.tar.gz --plugin-home ./plugin-home --force >/dev/null
 
 "${PLUGIN_CLI}" new --id acme.anthropic --name "Acme Anthropic" --runtime wasm_model_v1 --provider-profile anthropic.messages --out ./plugin-anthropic
 "${PLUGIN_CLI}" test --manifest ./plugin-anthropic/plugin.json --core-versions "0.1.0,0.2.0"
 "${PLUGIN_CLI}" pack --manifest ./plugin-anthropic/plugin.json
 "${PLUGIN_CLI}" verify --package ./plugin-anthropic/dist/acme.anthropic-0.1.0.tar.gz
+"${PLUGIN_CLI}" install --package ./plugin-anthropic/dist/acme.anthropic-0.1.0.tar.gz --plugin-home ./plugin-home --force >/dev/null
 
 "${PLUGIN_CLI}" new \
   --id acme.openrouter \
@@ -68,6 +73,7 @@ mv ./plugin-acme/plugin.json.tmp ./plugin-acme/plugin.json
 "${PLUGIN_CLI}" test --manifest ./plugin-openrouter/plugin.json --core-versions "0.1.0,0.2.0"
 "${PLUGIN_CLI}" pack --manifest ./plugin-openrouter/plugin.json
 "${PLUGIN_CLI}" verify --package ./plugin-openrouter/dist/acme.openrouter-0.1.0.tar.gz
+"${PLUGIN_CLI}" install --package ./plugin-openrouter/dist/acme.openrouter-0.1.0.tar.gz --plugin-home ./plugin-home --force >/dev/null
 
 # Signed-community tier should fail without plugin.sig.
 jq '.quality_tier = "signed_community" | .publisher = "acme"' ./plugin-acme/plugin.json > ./plugin-acme/plugin.json.tmp

--- a/templates/plugin-author-kit/README.md
+++ b/templates/plugin-author-kit/README.md
@@ -8,7 +8,14 @@ Primary command flow:
 scripts/kelvin-plugin.sh new --id acme.echo --name "Acme Echo" --runtime wasm_tool_v1
 scripts/kelvin-plugin.sh test --manifest ./plugin-acme.echo/plugin.json
 scripts/kelvin-plugin.sh pack --manifest ./plugin-acme.echo/plugin.json
+scripts/kelvin-plugin.sh install --package ./plugin-acme.echo/dist/acme.echo-0.1.0.tar.gz
 scripts/kelvin-plugin.sh verify --package ./plugin-acme.echo/dist/acme.echo-0.1.0.tar.gz
+```
+
+For model plugins, the supported local runtime loop is:
+
+```bash
+scripts/kelvin-plugin.sh smoke --manifest ./plugin.json
 ```
 
 For working model-plugin source, also see:


### PR DESCRIPTION
## Summary
- add first-class plugin install, index-install, and smoke commands to the Kelvin authoring CLI
- document the supported local contributor loop and encode the tarball cleanup follow-up in the gap analysis
- collapse release packaging to one Cargo build per target and improve the Ubuntu 24.04 author image for local cross-target validation

## Validation
- `./scripts/plugin-author-docker.sh -- bash -lc 'cargo fmt --all && scripts/test-plugin-author-kit.sh'`
- `./scripts/plugin-author-docker.sh -- bash -lc 'cd /work/examples/kelvin-openrouter-plugin && ../../scripts/kelvin-plugin.sh smoke --manifest ./plugin.json --prompt "Say hello"'`
- `./scripts/plugin-author-docker.sh -- bash -lc 'source /work/scripts/lib/rust-toolchain-path.sh && ensure_rust_toolchain_path || true; /work/scripts/package-linux-release.sh --target aarch64-unknown-linux-gnu --output-dir /work/.tmp/release-smoke-arm --target-dir /work/.tmp/release-target-arm --version 0.1.6-dev'`
- `bash -n scripts/kelvin-plugin.sh scripts/package-unix-release.sh scripts/kelvin scripts/test-plugin-author-kit.sh`
