### PR TITLE
Repin official plugin bundle to cleaned packages

### DIFF
--- a/docs/kelvin-gap-analysis.md
+++ b/docs/kelvin-gap-analysis.md
@@ -211,4 +211,4 @@ Still open:
 ## Near-Term TODO (Execution Order)
 
 1. Automate publisher key rotation pipelines for hosted plugin/trust-policy distribution.
-2. Republish legacy first-party plugin tarballs that still emit `LIBARCHIVE.xattr.com.apple.provenance` warnings on Linux installs, then update the official release plugin pins to the cleaned package versions.
+2. Completed in the current release line: republish legacy first-party plugin tarballs that emitted `LIBARCHIVE.xattr.com.apple.provenance` warnings on Linux installs, and update the official release plugin pins to the cleaned package versions.

--- a/release/official-first-party-plugins.env
+++ b/release/official-first-party-plugins.env
@@ -1,9 +1,9 @@
 OFFICIAL_TRUST_POLICY_URL="https://raw.githubusercontent.com/agentichighway/kelvinclaw-plugins/main/trusted_publishers.kelvin.json"
 
-KELVIN_CLI_VERSION="0.1.1"
-KELVIN_CLI_PACKAGE_URL="https://raw.githubusercontent.com/agentichighway/kelvinclaw-plugins/main/packages/kelvin.cli/0.1.1/kelvin.cli-0.1.1.tar.gz"
-KELVIN_CLI_SHA256="d59a1756ace124a897f2089ac7c788b68a9f673c19dbe0f0ee16611bebc494e3"
+KELVIN_CLI_VERSION="0.1.2"
+KELVIN_CLI_PACKAGE_URL="https://raw.githubusercontent.com/agentichighway/kelvinclaw-plugins/main/packages/kelvin.cli/0.1.2/kelvin.cli-0.1.2.tar.gz"
+KELVIN_CLI_SHA256="9f9a3611b299f76b2deafa21c09abad6d7c96f7486eb7a991a9bbb1dce8c5012"
 
-KELVIN_OPENAI_VERSION="0.1.1"
-KELVIN_OPENAI_PACKAGE_URL="https://raw.githubusercontent.com/agentichighway/kelvinclaw-plugins/main/packages/kelvin.openai/0.1.1/kelvin.openai-0.1.1.tar.gz"
-KELVIN_OPENAI_SHA256="946ff13cdd1246fc7438d590144a6d771a238cb030d09585cfe511e37bf52317"
+KELVIN_OPENAI_VERSION="0.1.2"
+KELVIN_OPENAI_PACKAGE_URL="https://raw.githubusercontent.com/agentichighway/kelvinclaw-plugins/main/packages/kelvin.openai/0.1.2/kelvin.openai-0.1.2.tar.gz"
+KELVIN_OPENAI_SHA256="7699b4c3fa4684cfa879c4c2e51111a8738c98236934424013b2f35b73216548"


### PR DESCRIPTION
## Summary
- repin the official release bundle to kelvin.cli@0.1.2 and kelvin.openai@0.1.2
- mark the Linux tar provenance cleanup item complete in the gap analysis

## Validation
- git diff --check
- verified ubuntu:24.04 tar extraction for the pinned plugin packages with empty stderr
