### PR TITLE
Prepare v0.1.7 release

### DIFF
--- a/.github/workflows/release-executables.yml
+++ b/.github/workflows/release-executables.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Optional release version label (for example 0.1.3 or v0.1.3)
+        description: Optional release version label (for example 0.1.7 or v0.1.7)
         required: false
         type: string
   push:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.7"
 edition = "2021"
 license = "MIT"
 authors = ["KelvinClaw Contributors"]

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -39,11 +39,11 @@ Example for Linux arm64:
 
 ```bash
 apt-get update && apt-get install -y curl ca-certificates
-curl -fsSL -O https://github.com/AgenticHighway/kelvinclaw/releases/download/v0.1.6/kelvinclaw-0.1.6-linux-arm64.tar.gz
-curl -fsSL -O https://github.com/AgenticHighway/kelvinclaw/releases/download/v0.1.6/kelvinclaw-0.1.6-linux-arm64.tar.gz.sha256
-sha256sum -c kelvinclaw-0.1.6-linux-arm64.tar.gz.sha256
-tar -xzf kelvinclaw-0.1.6-linux-arm64.tar.gz
-cd kelvinclaw-0.1.6-linux-arm64
+curl -fsSL -O https://github.com/AgenticHighway/kelvinclaw/releases/download/v0.1.7/kelvinclaw-0.1.7-linux-arm64.tar.gz
+curl -fsSL -O https://github.com/AgenticHighway/kelvinclaw/releases/download/v0.1.7/kelvinclaw-0.1.7-linux-arm64.tar.gz.sha256
+sha256sum -c kelvinclaw-0.1.7-linux-arm64.tar.gz.sha256
+tar -xzf kelvinclaw-0.1.7-linux-arm64.tar.gz
+cd kelvinclaw-0.1.7-linux-arm64
 printf 'OPENAI_API_KEY=%s\n' '<your_key>' > .env
 ./kelvin
 ```
@@ -52,11 +52,11 @@ Example for Linux x86_64:
 
 ```bash
 apt-get update && apt-get install -y curl ca-certificates
-curl -fsSL -O https://github.com/AgenticHighway/kelvinclaw/releases/download/v0.1.6/kelvinclaw-0.1.6-linux-x86_64.tar.gz
-curl -fsSL -O https://github.com/AgenticHighway/kelvinclaw/releases/download/v0.1.6/kelvinclaw-0.1.6-linux-x86_64.tar.gz.sha256
-sha256sum -c kelvinclaw-0.1.6-linux-x86_64.tar.gz.sha256
-tar -xzf kelvinclaw-0.1.6-linux-x86_64.tar.gz
-cd kelvinclaw-0.1.6-linux-x86_64
+curl -fsSL -O https://github.com/AgenticHighway/kelvinclaw/releases/download/v0.1.7/kelvinclaw-0.1.7-linux-x86_64.tar.gz
+curl -fsSL -O https://github.com/AgenticHighway/kelvinclaw/releases/download/v0.1.7/kelvinclaw-0.1.7-linux-x86_64.tar.gz.sha256
+sha256sum -c kelvinclaw-0.1.7-linux-x86_64.tar.gz.sha256
+tar -xzf kelvinclaw-0.1.7-linux-x86_64.tar.gz
+cd kelvinclaw-0.1.7-linux-x86_64
 printf 'OPENAI_API_KEY=%s\n' '<your_key>' > .env
 ./kelvin
 ```


### PR DESCRIPTION
## Summary
- align workspace version to 0.1.7
- update getting started examples to the upcoming v0.1.7 release assets
- refresh the release workflow input example to match the current version line

## Validation
- git diff --check
