### PR TITLE
update anthropic plugin to use 30000ms timeout instead of 5000ms

### DIFF
--- a/apps/kelvin-gateway/tests/gateway_ws.rs
+++ b/apps/kelvin-gateway/tests/gateway_ws.rs
@@ -328,7 +328,7 @@ async fn gateway_agent_submit_wait_and_idempotency_flow_works() {
         "agent.wait",
         json!({
             "run_id": run_id,
-            "timeout_ms": 5000,
+            "timeout_ms": 30000,
         }),
     )
     .await;

--- a/crates/kelvin-brain/src/installed_plugins.rs
+++ b/crates/kelvin-brain/src/installed_plugins.rs
@@ -27,7 +27,7 @@ use kelvin_wasm::{
 
 const DEFAULT_TOOL_RUNTIME_KIND: &str = "wasm_tool_v1";
 const DEFAULT_MODEL_RUNTIME_KIND: &str = "wasm_model_v1";
-const DEFAULT_TIMEOUT_MS: u64 = 2_000;
+const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 const DEFAULT_MAX_RETRIES: u32 = 0;
 const DEFAULT_MAX_CALLS_PER_MINUTE: usize = 120;
 const DEFAULT_CIRCUIT_BREAKER_FAILURES: u32 = 3;

--- a/crates/kelvin-sdk/src/lib.rs
+++ b/crates/kelvin-sdk/src/lib.rs
@@ -1729,7 +1729,7 @@ mod tests {
                     "network_allow_hosts": [allow_host]
                 },
                 "operational_controls": {
-                    "timeout_ms": 5000,
+                    "timeout_ms": 30000,
                     "max_retries": 0,
                     "max_calls_per_minute": 120,
                     "circuit_breaker_failures": 3,

--- a/crates/kelvin-wasm/src/model_host.rs
+++ b/crates/kelvin-wasm/src/model_host.rs
@@ -28,7 +28,7 @@ pub mod model_abi {
 
 const DEFAULT_MAX_REQUEST_BYTES: usize = 256 * 1024;
 const DEFAULT_MAX_RESPONSE_BYTES: usize = 1024 * 1024;
-const DEFAULT_TIMEOUT_MS: u64 = 10_000;
+const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModelSandboxPolicy {

--- a/examples/kelvin-anthropic-plugin/plugin.json
+++ b/examples/kelvin-anthropic-plugin/plugin.json
@@ -46,7 +46,7 @@
     ]
   },
   "operational_controls": {
-    "timeout_ms": 5000,
+    "timeout_ms": 30000,
     "max_retries": 0,
     "max_calls_per_minute": 120,
     "circuit_breaker_failures": 3,

--- a/examples/kelvin-openrouter-plugin/plugin.json
+++ b/examples/kelvin-openrouter-plugin/plugin.json
@@ -41,7 +41,7 @@
     ]
   },
   "operational_controls": {
-    "timeout_ms": 5000,
+    "timeout_ms": 30000,
     "max_retries": 0,
     "max_calls_per_minute": 120,
     "circuit_breaker_failures": 3,

--- a/scripts/kelvin-plugin.sh
+++ b/scripts/kelvin-plugin.sh
@@ -805,7 +805,7 @@ cmd_new() {
       model_name="$(protocol_family_default_model_name "${protocol_family}" "${provider_name}")"
     fi
     network_allow_hosts="$(printf '%s\n' "${allow_hosts[@]}" | jq -R . | jq -s .)"
-    timeout_ms="5000"
+    timeout_ms="30000"
     capabilities='["model_provider","network_egress"]'
     provider_profile_json="$(jq -cn \
       --arg id "${provider_profile_id}" \

--- a/scripts/test-cli-plugin-integration.sh
+++ b/scripts/test-cli-plugin-integration.sh
@@ -42,7 +42,7 @@ KELVIN_TRUST_POLICY_PATH="${TRUST_POLICY_PATH}" \
 CARGO_TARGET_DIR="${TARGET_DIR}" \
   cargo run -p kelvin-host -- \
     --prompt "integration sdk lane" \
-    --timeout-ms 5000 > "${LOG_PATH}"
+    --timeout-ms 30000 > "${LOG_PATH}"
 
 if ! grep -q "cli plugin preflight: kelvin_cli executed" "${LOG_PATH}"; then
   echo "[test-cli-plugin-integration] expected cli plugin preflight output not found" >&2

--- a/scripts/try-kelvin.sh
+++ b/scripts/try-kelvin.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${ROOT_DIR}/scripts/lib/rust-toolchain-path.sh"
 source "${ROOT_DIR}/scripts/lib/docker-cache.sh"
 PROMPT="${1:-hello kelvin}"
-TIMEOUT_MS="${KELVIN_TRY_TIMEOUT_MS:-5000}"
+TIMEOUT_MS="${KELVIN_TRY_TIMEOUT_MS:-30000}"
 MODE="${KELVIN_TRY_MODE:-auto}" # auto | local | docker
 TARGET_DIR="${KELVIN_TRY_TARGET_DIR:-${ROOT_DIR}/target}"
 PLUGIN_HOME="${KELVIN_PLUGIN_HOME:-${ROOT_DIR}/.kelvin/plugins}"

--- a/templates/plugin-author-kit/wasm_model/plugin.json.template
+++ b/templates/plugin-author-kit/wasm_model/plugin.json.template
@@ -41,7 +41,7 @@
     ]
   },
   "operational_controls": {
-    "timeout_ms": 5000,
+    "timeout_ms": 30000,
     "max_retries": 0,
     "max_calls_per_minute": 120,
     "circuit_breaker_failures": 3,


### PR DESCRIPTION
# Anthropic Timeout Update

## Problem

the default timeout (5000ms) was too short for TTFT. on more complex prompts, it times out and fails before anthropic sends and response.

To reproduce, try the prompt "write 1000 words about flowers".

## Fixes

- update the default values in the core codebase
- update anthropic + openrouter plugins with new manifest

## Todo items

- update these packages on kevlin-plugins repo with official signatures