### PR TITLE
style: apply cargo fmt --all

### DIFF
--- a/apps/kelvin-gateway/src/lib.rs
+++ b/apps/kelvin-gateway/src/lib.rs
@@ -1223,7 +1223,9 @@ async fn handle_request(
         "commands.list" => Ok(commands_list_payload(&state.runtime)),
         "command.exec" => {
             let params: CommandExecParams = parse_params(params, method)?;
-            command_exec_payload(&state.runtime, params).await.map_err(map_kelvin_error)
+            command_exec_payload(&state.runtime, params)
+                .await
+                .map_err(map_kelvin_error)
         }
         _ => Err(GatewayErrorPayload {
             code: "method_not_found".to_string(),
@@ -1360,12 +1362,17 @@ async fn command_exec_payload(
     match name {
         "new" => {
             let session_id = params.session_id.as_deref().unwrap_or("main");
-            let workspace_dir = runtime.default_workspace_dir().to_string_lossy().to_string();
-            runtime.upsert_session(SessionDescriptor {
-                session_id: session_id.to_string(),
-                session_key: session_id.to_string(),
-                workspace_dir,
-            }).await?;
+            let workspace_dir = runtime
+                .default_workspace_dir()
+                .to_string_lossy()
+                .to_string();
+            runtime
+                .upsert_session(SessionDescriptor {
+                    session_id: session_id.to_string(),
+                    session_key: session_id.to_string(),
+                    workspace_dir,
+                })
+                .await?;
             Ok(json!({ "command": "new", "session_id": session_id }))
         }
         "switch" => {
@@ -1388,10 +1395,11 @@ async fn command_exec_payload(
                 })).collect::<Vec<_>>(),
             }))
         }
-        "sessions" => {
-            operator::sessions_list_payload(runtime, operator::OperatorSessionsListParams::default())
-                .map(|payload| json!({ "command": "sessions", "result": payload }))
-        }
+        "sessions" => operator::sessions_list_payload(
+            runtime,
+            operator::OperatorSessionsListParams::default(),
+        )
+        .map(|payload| json!({ "command": "sessions", "result": payload })),
         "plugins" => {
             let payload = operator::plugins_inspect_payload(
                 runtime,

--- a/apps/kelvin-tui/src/app.rs
+++ b/apps/kelvin-tui/src/app.rs
@@ -2,8 +2,10 @@ use std::time::{Duration, Instant};
 
 use crossterm::{
     cursor::SetCursorStyle,
-    event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
-            Event, EventStream, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventKind},
+    event::{
+        DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+        Event, EventStream, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventKind,
+    },
     execute,
     terminal::{enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -117,12 +119,18 @@ pub struct PasteMarker {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SelectionTarget { Chat, Tools }
+pub enum SelectionTarget {
+    Chat,
+    Tools,
+}
 
 /// A position in the flat Vec<Line> built by chat::render.
 /// `col` is a display-column offset within the full content line (including prefix spans).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ChatPos { pub line_idx: usize, pub col: usize }
+pub struct ChatPos {
+    pub line_idx: usize,
+    pub col: usize,
+}
 
 #[derive(Debug, Clone)]
 pub struct Selection {
@@ -249,7 +257,7 @@ pub struct App {
     pub selection: Option<Selection>,
     pub chat_line_map: Vec<(usize, usize)>, // visual_row -> (content_line_idx, char_start_col)
     pub chat_line_info: Vec<ChatLineInfo>,
-    pub chat_line_texts: Vec<String>,       // per content line, prefix stripped (empty for separators)
+    pub chat_line_texts: Vec<String>, // per content line, prefix stripped (empty for separators)
     pub command_registry: MergedCommandRegistry,
     pub autocomplete_visible: bool,
     pub autocomplete_items: Vec<CompletionItem>,
@@ -309,7 +317,8 @@ impl App {
     }
 
     pub fn do_paste(&mut self, text: String) {
-        self.paste_markers.retain(|m| m.end <= self.cursor_pos || m.start >= self.cursor_pos);
+        self.paste_markers
+            .retain(|m| m.end <= self.cursor_pos || m.start >= self.cursor_pos);
 
         let start = self.cursor_pos;
         let len = text.len();
@@ -324,7 +333,14 @@ impl App {
                 }
             }
             let idx = self.paste_markers.partition_point(|m| m.start < start);
-            self.paste_markers.insert(idx, PasteMarker { start, end: start + len, label });
+            self.paste_markers.insert(
+                idx,
+                PasteMarker {
+                    start,
+                    end: start + len,
+                    label,
+                },
+            );
         } else {
             self.input.insert_str(start, &text);
             for m in &mut self.paste_markers {
@@ -344,7 +360,11 @@ impl App {
         if self.cursor_pos >= self.input.len() {
             return;
         }
-        if let Some(idx) = self.paste_markers.iter().position(|m| m.start == self.cursor_pos) {
+        if let Some(idx) = self
+            .paste_markers
+            .iter()
+            .position(|m| m.start == self.cursor_pos)
+        {
             let m = self.paste_markers.remove(idx);
             let removed = m.end - m.start;
             self.input.drain(m.start..m.end);
@@ -376,7 +396,11 @@ impl App {
         if self.cursor_pos == 0 {
             return;
         }
-        if let Some(idx) = self.paste_markers.iter().position(|m| m.end == self.cursor_pos) {
+        if let Some(idx) = self
+            .paste_markers
+            .iter()
+            .position(|m| m.end == self.cursor_pos)
+        {
             let m = self.paste_markers.remove(idx);
             let removed = m.end - m.start;
             self.input.drain(m.start..m.end);
@@ -407,7 +431,9 @@ impl App {
     }
 
     pub fn move_left(&mut self) {
-        if self.cursor_pos == 0 { return; }
+        if self.cursor_pos == 0 {
+            return;
+        }
         if let Some(m) = self.paste_markers.iter().find(|m| m.end == self.cursor_pos) {
             self.cursor_pos = m.start;
         } else {
@@ -420,8 +446,14 @@ impl App {
     }
 
     pub fn move_right(&mut self) {
-        if self.cursor_pos >= self.input.len() { return; }
-        if let Some(m) = self.paste_markers.iter().find(|m| m.start == self.cursor_pos) {
+        if self.cursor_pos >= self.input.len() {
+            return;
+        }
+        if let Some(m) = self
+            .paste_markers
+            .iter()
+            .find(|m| m.start == self.cursor_pos)
+        {
             self.cursor_pos = m.end;
         } else {
             let mut new_pos = self.cursor_pos + 1;
@@ -434,10 +466,14 @@ impl App {
 
     fn compact_chat(&mut self) {
         const MAX_CHAT_MESSAGES: usize = 1000;
-        if self.chat.len() <= MAX_CHAT_MESSAGES { return; }
+        if self.chat.len() <= MAX_CHAT_MESSAGES {
+            return;
+        }
         let to_remove = self.chat.len() - MAX_CHAT_MESSAGES;
         let prior_count = match self.chat.first() {
-            Some(ChatMessage::System(s)) if s.starts_with('[') && s.contains("earlier messages omitted") => {
+            Some(ChatMessage::System(s))
+                if s.starts_with('[') && s.contains("earlier messages omitted") =>
+            {
                 s.trim_start_matches('[')
                     .split_whitespace()
                     .next()
@@ -451,14 +487,19 @@ impl App {
         if prior_count > 0 {
             self.chat[0] = ChatMessage::System(format!("[{total} earlier messages omitted]"));
         } else {
-            self.chat.insert(0, ChatMessage::System(format!("[{total} earlier messages omitted]")));
+            self.chat.insert(
+                0,
+                ChatMessage::System(format!("[{total} earlier messages omitted]")),
+            );
         }
         self.selection = None; // line indices shifted
     }
 
     pub fn handle_agent_event(&mut self, ev: AgentEvent) {
         match ev.data {
-            AgentEventData::Assistant { delta, final_chunk, .. } => {
+            AgentEventData::Assistant {
+                delta, final_chunk, ..
+            } => {
                 if let Some(ChatMessage::Assistant { text, complete }) = self.chat.last_mut() {
                     if !*complete {
                         text.push_str(&delta);
@@ -474,7 +515,13 @@ impl App {
                 });
                 self.chat_pinned = true;
             }
-            AgentEventData::Tool { tool_name, phase, summary, ts_ms, .. } => {
+            AgentEventData::Tool {
+                tool_name,
+                phase,
+                summary,
+                ts_ms,
+                ..
+            } => {
                 if let ToolPhase::Start = phase {
                     if let Some(ChatMessage::Assistant { complete, .. }) = self.chat.last_mut() {
                         *complete = true;
@@ -487,8 +534,10 @@ impl App {
                         ended_ms: None,
                     });
                 } else {
-                    if let Some(entry) = self.tools.iter_mut().rev()
-                        .find(|t| t.tool_name == tool_name && matches!(t.phase, ToolPhase::Start))
+                    if let Some(entry) =
+                        self.tools.iter_mut().rev().find(|t| {
+                            t.tool_name == tool_name && matches!(t.phase, ToolPhase::Start)
+                        })
                     {
                         entry.phase = phase;
                         entry.summary = summary.or(entry.summary.clone());
@@ -504,7 +553,12 @@ impl App {
                     }
                 }
             }
-            AgentEventData::Lifecycle { run_id, phase, message, .. } => {
+            AgentEventData::Lifecycle {
+                run_id,
+                phase,
+                message,
+                ..
+            } => {
                 match &phase {
                     LifecyclePhase::Start => {
                         self.current_run_id = Some(run_id);
@@ -536,22 +590,41 @@ fn in_rect(col: u16, row: u16, r: Rect) -> bool {
 fn screen_to_chat_pos(col: u16, row: u16, app: &App) -> Option<ChatPos> {
     let inner_x = app.chat_area.x + 1;
     let inner_y = app.chat_area.y + 1;
-    if col < inner_x || row < inner_y { return None; }
+    if col < inner_x || row < inner_y {
+        return None;
+    }
     let rel_col = (col - inner_x) as usize;
     let rel_row = (row - inner_y) as usize;
-    let scroll = if app.chat_pinned { app.chat_max_scroll } else { app.chat_scroll.min(app.chat_max_scroll) };
+    let scroll = if app.chat_pinned {
+        app.chat_max_scroll
+    } else {
+        app.chat_scroll.min(app.chat_max_scroll)
+    };
     let abs_row = rel_row + scroll;
     let &(line_idx, char_start_col) = app.chat_line_map.get(abs_row)?;
-    Some(ChatPos { line_idx, col: char_start_col + rel_col })
+    Some(ChatPos {
+        line_idx,
+        col: char_start_col + rel_col,
+    })
 }
 
 fn screen_to_tools_row(row: u16, app: &App) -> Option<usize> {
     let header_row = app.tools_area.y + 2; // top border + header row
-    if row < header_row { return None; }
+    if row < header_row {
+        return None;
+    }
     let rel_row = (row - header_row) as usize;
-    let offset = if app.tools_pinned { app.tools_max_scroll } else { app.tools_scroll.min(app.tools_max_scroll) };
+    let offset = if app.tools_pinned {
+        app.tools_max_scroll
+    } else {
+        app.tools_scroll.min(app.tools_max_scroll)
+    };
     let idx = rel_row + offset;
-    if idx < app.tools.len() { Some(idx) } else { None }
+    if idx < app.tools.len() {
+        Some(idx)
+    } else {
+        None
+    }
 }
 
 fn extract_selected_text(app: &App) -> String {
@@ -560,16 +633,26 @@ fn extract_selected_text(app: &App) -> String {
         Some(sel) if sel.target == SelectionTarget::Tools => {
             let idx = sel.anchor.line_idx;
             if let Some(e) = app.tools.get(idx) {
-                let phase = match e.phase { ToolPhase::Start => "running", ToolPhase::End => "done", ToolPhase::Error => "error" };
+                let phase = match e.phase {
+                    ToolPhase::Start => "running",
+                    ToolPhase::End => "done",
+                    ToolPhase::Error => "error",
+                };
                 let summary = e.summary.as_deref().unwrap_or("");
-                let dur = e.ended_ms.map_or("...".into(), |end| format!("{}ms", end.saturating_sub(e.started_ms)));
+                let dur = e.ended_ms.map_or("...".into(), |end| {
+                    format!("{}ms", end.saturating_sub(e.started_ms))
+                });
                 format!("{}\t{}\t{}\t{}", e.tool_name, phase, summary, dur)
-            } else { String::new() }
+            } else {
+                String::new()
+            }
         }
         Some(sel) => {
             let (start, end) = sel.normalized();
             let n = app.chat_line_texts.len();
-            if start.line_idx >= n { return String::new(); }
+            if start.line_idx >= n {
+                return String::new();
+            }
             // If the drag ended at column 0, the cursor is before that line — exclude it.
             let end_idx = if end.col == 0 && end.line_idx > start.line_idx {
                 end.line_idx - 1
@@ -579,7 +662,9 @@ fn extract_selected_text(app: &App) -> String {
             let mut result = String::new();
             for idx in start.line_idx..=end_idx {
                 let info = &app.chat_line_info[idx];
-                if info.is_separator { continue; }
+                if info.is_separator {
+                    continue;
+                }
                 let clean = &app.chat_line_texts[idx];
                 let sel_start = if idx == start.line_idx { start.col } else { 0 };
                 let sel_end = if idx == end_idx { end.col } else { usize::MAX };
@@ -589,12 +674,20 @@ fn extract_selected_text(app: &App) -> String {
                 } else {
                     let t = sel_end.saturating_sub(info.prefix_width);
                     // Selection lands within the prefix — include the full line.
-                    if t == 0 && sel_end > 0 { clean.len() } else { t }
+                    if t == 0 && sel_end > 0 {
+                        clean.len()
+                    } else {
+                        t
+                    }
                 };
                 let byte_start = display_col_to_byte(clean, text_start);
-                let byte_end = display_col_to_byte(clean, text_end).max(byte_start).min(clean.len());
+                let byte_end = display_col_to_byte(clean, text_end)
+                    .max(byte_start)
+                    .min(clean.len());
                 let slice = &clean[byte_start..byte_end];
-                if !result.is_empty() { result.push('\n'); }
+                if !result.is_empty() {
+                    result.push('\n');
+                }
                 result.push_str(slice);
             }
             result
@@ -605,7 +698,9 @@ fn extract_selected_text(app: &App) -> String {
 fn display_col_to_byte(s: &str, col: usize) -> usize {
     let mut width = 0usize;
     for (byte_idx, ch) in s.char_indices() {
-        if width >= col { return byte_idx; }
+        if width >= col {
+            return byte_idx;
+        }
         width += ch.width().unwrap_or(0);
     }
     s.len()
@@ -628,8 +723,16 @@ fn base64_encode(data: &[u8]) -> String {
         let n = (b0 << 16) | (b1 << 8) | b2;
         out.push(T[((n >> 18) & 0x3f) as usize] as char);
         out.push(T[((n >> 12) & 0x3f) as usize] as char);
-        out.push(if chunk.len() > 1 { T[((n >> 6) & 0x3f) as usize] as char } else { '=' });
-        out.push(if chunk.len() > 2 { T[(n & 0x3f) as usize] as char } else { '=' });
+        out.push(if chunk.len() > 1 {
+            T[((n >> 6) & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            T[(n & 0x3f) as usize] as char
+        } else {
+            '='
+        });
     }
     out
 }
@@ -662,7 +765,10 @@ fn update_autocomplete(app: &mut App) {
 
 /// Format a command result payload into a readable string for the chat.
 fn format_command_result(payload: &serde_json::Value) -> String {
-    let command = payload.get("command").and_then(|v| v.as_str()).unwrap_or("?");
+    let command = payload
+        .get("command")
+        .and_then(|v| v.as_str())
+        .unwrap_or("?");
     match command {
         "tools" => {
             let count = payload.get("count").and_then(|v| v.as_u64()).unwrap_or(0);
@@ -670,7 +776,10 @@ fn format_command_result(payload: &serde_json::Value) -> String {
             if let Some(tools) = payload.get("tools").and_then(|v| v.as_array()) {
                 for tool in tools {
                     let name = tool.get("name").and_then(|v| v.as_str()).unwrap_or("?");
-                    let desc = tool.get("description").and_then(|v| v.as_str()).unwrap_or("");
+                    let desc = tool
+                        .get("description")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
                     lines.push(format!("  • {name} — {desc}"));
                 }
             }
@@ -685,7 +794,10 @@ fn format_command_result(payload: &serde_json::Value) -> String {
                 for s in sessions {
                     let id = s.get("session_id").and_then(|v| v.as_str()).unwrap_or("?");
                     let msgs = s.get("message_count").and_then(|v| v.as_u64()).unwrap_or(0);
-                    let workspace = s.get("workspace_dir").and_then(|v| v.as_str()).unwrap_or("");
+                    let workspace = s
+                        .get("workspace_dir")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
                     lines.push(format!("  • {id}  ({msgs} msgs)  {workspace}"));
                 }
             }
@@ -693,7 +805,10 @@ fn format_command_result(payload: &serde_json::Value) -> String {
         }
         "plugins" => {
             let result = payload.get("result").unwrap_or(payload);
-            let loaded = result.get("loaded_installed_plugins").and_then(|v| v.as_u64()).unwrap_or(0);
+            let loaded = result
+                .get("loaded_installed_plugins")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
             let plugins = result.get("plugins").and_then(|v| v.as_array());
             let total = plugins.map(|p| p.len()).unwrap_or(0);
             let mut lines = vec![format!("Plugins ({loaded} loaded, {total} installed):")];
@@ -711,11 +826,17 @@ fn format_command_result(payload: &serde_json::Value) -> String {
         }
         "clear" => "Session history cleared.".to_string(),
         "new" => {
-            let sid = payload.get("session_id").and_then(|v| v.as_str()).unwrap_or("?");
+            let sid = payload
+                .get("session_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("?");
             format!("New session created: {sid}")
         }
         "switch" => {
-            let sid = payload.get("session_id").and_then(|v| v.as_str()).unwrap_or("?");
+            let sid = payload
+                .get("session_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("?");
             format!("Switched to session: {sid}")
         }
         _ => serde_json::to_string_pretty(payload).unwrap_or_else(|_| format!("{payload}")),
@@ -725,11 +846,15 @@ fn format_command_result(payload: &serde_json::Value) -> String {
 fn word_left(s: &str, pos: usize) -> usize {
     let mut current = pos;
     for c in s[..current].chars().rev() {
-        if is_word_char(c) { break; }
+        if is_word_char(c) {
+            break;
+        }
         current -= c.len_utf8();
     }
     for c in s[..current].chars().rev() {
-        if !is_word_char(c) { break; }
+        if !is_word_char(c) {
+            break;
+        }
         current -= c.len_utf8();
     }
     current
@@ -738,11 +863,15 @@ fn word_left(s: &str, pos: usize) -> usize {
 fn word_right(s: &str, pos: usize) -> usize {
     let mut current = pos;
     for c in s[current..].chars() {
-        if is_word_char(c) { break; }
+        if is_word_char(c) {
+            break;
+        }
         current += c.len_utf8();
     }
     for c in s[current..].chars() {
-        if !is_word_char(c) { break; }
+        if !is_word_char(c) {
+            break;
+        }
         current += c.len_utf8();
     }
     current
@@ -752,7 +881,10 @@ fn word_right(s: &str, pos: usize) -> usize {
 fn assert_markers_valid(input: &str, markers: &[PasteMarker]) {
     for i in 0..markers.len() {
         assert!(markers[i].start < markers[i].end, "marker {i} start >= end");
-        assert!(markers[i].end <= input.len(), "marker {i} end out of bounds");
+        assert!(
+            markers[i].end <= input.len(),
+            "marker {i} end out of bounds"
+        );
         if i + 1 < markers.len() {
             assert!(
                 markers[i].end <= markers[i + 1].start,
@@ -764,7 +896,9 @@ fn assert_markers_valid(input: &str, markers: &[PasteMarker]) {
 }
 
 fn visual_line_start(display_pos: usize, inner_width: usize) -> usize {
-    if inner_width < 3 { return 0; }
+    if inner_width < 3 {
+        return 0;
+    }
     let prefix = 2;
     let first_cap = inner_width - prefix;
     if display_pos <= first_cap {
@@ -776,7 +910,9 @@ fn visual_line_start(display_pos: usize, inner_width: usize) -> usize {
 }
 
 fn visual_line_end(display_pos: usize, display_len: usize, inner_width: usize) -> usize {
-    if inner_width < 3 { return display_len; }
+    if inner_width < 3 {
+        return display_len;
+    }
     let prefix = 2;
     let first_cap = inner_width - prefix;
     let end = if display_pos < first_cap {
@@ -813,8 +949,13 @@ pub async fn run(config: CliConfig) -> Result<(), String> {
 
     enable_raw_mode().map_err(|e| format!("enable raw mode: {e}"))?;
     let mut stdout = std::io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableBracketedPaste, SetCursorStyle::SteadyBlock)
-        .map_err(|e| format!("enter alt screen: {e}"))?;
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        EnableBracketedPaste,
+        SetCursorStyle::SteadyBlock
+    )
+    .map_err(|e| format!("enter alt screen: {e}"))?;
     // best-effort: mouse scroll still works without this on some terminals
     let _ = execute!(stdout, EnableMouseCapture);
 
@@ -826,12 +967,20 @@ pub async fn run(config: CliConfig) -> Result<(), String> {
     let mut app = App::new(config.gateway_url.clone(), config.session_id.clone());
     app.auth_token = config.auth_token.clone();
 
-    let ws_result = WsClient::connect(&config.gateway_url, config.auth_token.clone(), tui_tx.clone()).await;
+    let ws_result = WsClient::connect(
+        &config.gateway_url,
+        config.auth_token.clone(),
+        tui_tx.clone(),
+    )
+    .await;
     let ws_client = match ws_result {
         Ok(client) => {
             app.ws_status = WsStatus::Connected;
             app.chat.clear();
-            app.chat.push(ChatMessage::System(format!("Connected to {}", config.gateway_url)));
+            app.chat.push(ChatMessage::System(format!(
+                "Connected to {}",
+                config.gateway_url
+            )));
             // Fetch available commands from the gateway.
             let fetch_client = client.clone();
             let tx = tui_tx.clone();
@@ -844,7 +993,8 @@ pub async fn run(config: CliConfig) -> Result<(), String> {
         Err(e) => {
             app.ws_status = WsStatus::Error(e.clone());
             app.last_error = Some(e.clone());
-            app.chat.push(ChatMessage::System(format!("Connection failed: {e}")));
+            app.chat
+                .push(ChatMessage::System(format!("Connection failed: {e}")));
             None
         }
     };
@@ -854,10 +1004,18 @@ pub async fn run(config: CliConfig) -> Result<(), String> {
         let mut reader = EventStream::new();
         while let Some(Ok(event)) = reader.next().await {
             match event {
-                Event::Key(key) => { let _ = tui_tx_key.send(TuiEvent::Key(key)).await; }
-                Event::Paste(text) => { let _ = tui_tx_key.send(TuiEvent::Paste(text)).await; }
-                Event::Resize(w, h) => { let _ = tui_tx_key.send(TuiEvent::Resize(w, h)).await; }
-                Event::Mouse(e) => { let _ = tui_tx_key.send(TuiEvent::Mouse(e)).await; }
+                Event::Key(key) => {
+                    let _ = tui_tx_key.send(TuiEvent::Key(key)).await;
+                }
+                Event::Paste(text) => {
+                    let _ = tui_tx_key.send(TuiEvent::Paste(text)).await;
+                }
+                Event::Resize(w, h) => {
+                    let _ = tui_tx_key.send(TuiEvent::Resize(w, h)).await;
+                }
+                Event::Mouse(e) => {
+                    let _ = tui_tx_key.send(TuiEvent::Mouse(e)).await;
+                }
                 _ => {}
             }
         }
@@ -874,7 +1032,14 @@ pub async fn run(config: CliConfig) -> Result<(), String> {
         }
     });
 
-    let result = run_loop(&mut terminal, &mut app, &mut tui_rx, tui_tx.clone(), ws_client).await;
+    let result = run_loop(
+        &mut terminal,
+        &mut app,
+        &mut tui_rx,
+        tui_tx.clone(),
+        ws_client,
+    )
+    .await;
 
     key_task.abort();
     tick_task.abort();
@@ -892,7 +1057,9 @@ async fn run_loop(
 ) -> Result<(), String> {
     let mut ws_client = ws_client;
     loop {
-        let frame = terminal.draw(|f| ui::render(f, app)).map_err(|e| format!("draw: {e}"))?;
+        let frame = terminal
+            .draw(|f| ui::render(f, app))
+            .map_err(|e| format!("draw: {e}"))?;
         app.input_inner_width = frame.area.width.saturating_sub(2) as usize;
 
         let event = tui_rx.recv().await.ok_or("event channel closed")?;
@@ -918,7 +1085,9 @@ async fn run_loop(
                             app.selection = None;
                         } else {
                             let now = Instant::now();
-                            if app.last_ctrl_c.map_or(false, |t| now.duration_since(t) < Duration::from_millis(500)) {
+                            if app.last_ctrl_c.map_or(false, |t| {
+                                now.duration_since(t) < Duration::from_millis(500)
+                            }) {
                                 app.should_quit = true;
                             } else {
                                 app.last_ctrl_c = Some(now);
@@ -939,7 +1108,9 @@ async fn run_loop(
                         if app.autocomplete_visible
                             && app.autocomplete_selected < app.autocomplete_items.len()
                         {
-                            let name = app.autocomplete_items[app.autocomplete_selected].name.clone();
+                            let name = app.autocomplete_items[app.autocomplete_selected]
+                                .name
+                                .clone();
                             app.input = format!("/{name}");
                             app.cursor_pos = app.input.len();
                             app.autocomplete_visible = false;
@@ -951,7 +1122,8 @@ async fn run_loop(
                             app.input_history.push(prompt.clone());
                             const MAX_INPUT_HISTORY: usize = 500;
                             if app.input_history.len() > MAX_INPUT_HISTORY {
-                                app.input_history.drain(0..app.input_history.len() - MAX_INPUT_HISTORY);
+                                app.input_history
+                                    .drain(0..app.input_history.len() - MAX_INPUT_HISTORY);
                             }
                             app.history_idx = None;
                             app.history_saved.clear();
@@ -964,7 +1136,9 @@ async fn run_loop(
                             app.autocomplete_selected = 0;
 
                             // Dispatch slash commands; send everything else as a prompt.
-                            if let Some((cmd_name, args)) = crate::commands::parse_slash_input(&prompt) {
+                            if let Some((cmd_name, args)) =
+                                crate::commands::parse_slash_input(&prompt)
+                            {
                                 match app.command_registry.resolve(&cmd_name) {
                                     Some(SlashCommand::Local(LocalCommand::Quit)) => {
                                         app.should_quit = true;
@@ -979,16 +1153,20 @@ async fn run_loop(
                                                 let sid = app.session_id.clone();
                                                 let tx = tui_tx.clone();
                                                 tokio::spawn(async move {
-                                                    let result = client.exec_command(
-                                                        "clear",
-                                                        serde_json::Value::Null,
-                                                        &sid,
-                                                    ).await;
+                                                    let result = client
+                                                        .exec_command(
+                                                            "clear",
+                                                            serde_json::Value::Null,
+                                                            &sid,
+                                                        )
+                                                        .await;
                                                     // Notify on error only.
                                                     if let Err(e) = result {
-                                                        let _ = tx.send(TuiEvent::CommandResult(
-                                                            Err(format!("/clear failed: {e}"))
-                                                        )).await;
+                                                        let _ = tx
+                                                            .send(TuiEvent::CommandResult(Err(
+                                                                format!("/clear failed: {e}"),
+                                                            )))
+                                                            .await;
                                                     }
                                                 });
                                             }
@@ -1007,9 +1185,9 @@ async fn run_loop(
                                         app.session_id = new_id.clone();
                                         app.chat.clear();
                                         app.tools.clear();
-                                        app.chat.push(ChatMessage::System(
-                                            format!("Switched to new session: {new_id}")
-                                        ));
+                                        app.chat.push(ChatMessage::System(format!(
+                                            "Switched to new session: {new_id}"
+                                        )));
                                         if app.ws_status == WsStatus::Connected {
                                             if let Some(ref client) = ws_client {
                                                 let client = client.clone();
@@ -1022,9 +1200,13 @@ async fn run_loop(
                                                         &sid,
                                                     ).await;
                                                     if let Err(e) = result {
-                                                        let _ = tx.send(TuiEvent::CommandResult(
-                                                            Err(format!("/new failed on gateway: {e}"))
-                                                        )).await;
+                                                        let _ = tx
+                                                            .send(TuiEvent::CommandResult(Err(
+                                                                format!(
+                                                                    "/new failed on gateway: {e}"
+                                                                ),
+                                                            )))
+                                                            .await;
                                                     }
                                                 });
                                             }
@@ -1040,17 +1222,21 @@ async fn run_loop(
                                                     let sid = app.session_id.clone();
                                                     let tx = tui_tx.clone();
                                                     tokio::spawn(async move {
-                                                        let result = client.exec_command(
-                                                            "sessions",
-                                                            serde_json::Value::Null,
-                                                            &sid,
-                                                        ).await;
-                                                        let _ = tx.send(TuiEvent::CommandResult(result)).await;
+                                                        let result = client
+                                                            .exec_command(
+                                                                "sessions",
+                                                                serde_json::Value::Null,
+                                                                &sid,
+                                                            )
+                                                            .await;
+                                                        let _ = tx
+                                                            .send(TuiEvent::CommandResult(result))
+                                                            .await;
                                                     });
                                                 }
                                             } else {
                                                 app.chat.push(ChatMessage::System(
-                                                    "not connected to gateway".to_string()
+                                                    "not connected to gateway".to_string(),
                                                 ));
                                             }
                                         } else {
@@ -1059,9 +1245,9 @@ async fn run_loop(
                                             app.session_id = target_id.clone();
                                             app.chat.clear();
                                             app.tools.clear();
-                                            app.chat.push(ChatMessage::System(
-                                                format!("Switched to session: {target_id}")
-                                            ));
+                                            app.chat.push(ChatMessage::System(format!(
+                                                "Switched to session: {target_id}"
+                                            )));
                                             if app.ws_status == WsStatus::Connected {
                                                 if let Some(ref client) = ws_client {
                                                     let client = client.clone();
@@ -1089,7 +1275,9 @@ async fn run_loop(
                                         app.tools_scroll = 0;
                                         app.run_phase = None;
                                         if app.ws_status != WsStatus::Connected {
-                                            app.chat.push(ChatMessage::System("not connected to gateway".to_string()));
+                                            app.chat.push(ChatMessage::System(
+                                                "not connected to gateway".to_string(),
+                                            ));
                                         } else if let Some(ref client) = ws_client {
                                             let client = client.clone();
                                             let session_id = app.session_id.clone();
@@ -1100,8 +1288,11 @@ async fn run_loop(
                                                 serde_json::Value::String(args)
                                             };
                                             tokio::spawn(async move {
-                                                let result = client.exec_command(&name, args_value, &session_id).await;
-                                                let _ = tx.send(TuiEvent::CommandResult(result)).await;
+                                                let result = client
+                                                    .exec_command(&name, args_value, &session_id)
+                                                    .await;
+                                                let _ =
+                                                    tx.send(TuiEvent::CommandResult(result)).await;
                                             });
                                         }
                                     }
@@ -1118,17 +1309,22 @@ async fn run_loop(
                                 app.tools_scroll = 0;
                                 app.run_phase = None;
                                 if app.ws_status != WsStatus::Connected {
-                                    app.chat.push(ChatMessage::System("not connected to gateway".to_string()));
+                                    app.chat.push(ChatMessage::System(
+                                        "not connected to gateway".to_string(),
+                                    ));
                                 } else if let Some(ref client) = ws_client {
                                     let client = client.clone();
                                     let session_id = app.session_id.clone();
                                     let tx = tui_tx.clone();
                                     tokio::spawn(async move {
-                                        let result = client.submit_prompt(&prompt, &session_id).await;
+                                        let result =
+                                            client.submit_prompt(&prompt, &session_id).await;
                                         let _ = tx.send(TuiEvent::SubmitResult(result)).await;
                                     });
                                 } else {
-                                    app.chat.push(ChatMessage::System("not connected to gateway".to_string()));
+                                    app.chat.push(ChatMessage::System(
+                                        "not connected to gateway".to_string(),
+                                    ));
                                 }
                             }
                         }
@@ -1154,7 +1350,8 @@ async fn run_loop(
                     }
                     KeyCode::BackTab => {
                         if app.autocomplete_visible && !app.autocomplete_items.is_empty() {
-                            app.autocomplete_selected = app.autocomplete_selected
+                            app.autocomplete_selected = app
+                                .autocomplete_selected
                                 .checked_sub(1)
                                 .unwrap_or(app.autocomplete_items.len() - 1);
                         }
@@ -1169,18 +1366,26 @@ async fn run_loop(
                     }
                     KeyCode::Left if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         let new_pos = word_left(&app.input, app.cursor_pos);
-                        app.cursor_pos = app.paste_markers.iter()
+                        app.cursor_pos = app
+                            .paste_markers
+                            .iter()
                             .find(|m| new_pos > m.start && new_pos < m.end)
                             .map_or(new_pos, |m| m.start);
                     }
                     KeyCode::Right if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         let new_pos = word_right(&app.input, app.cursor_pos);
-                        app.cursor_pos = app.paste_markers.iter()
+                        app.cursor_pos = app
+                            .paste_markers
+                            .iter()
                             .find(|m| new_pos > m.start && new_pos < m.end)
                             .map_or(new_pos, |m| m.end);
                     }
-                    KeyCode::Left => { app.move_left(); }
-                    KeyCode::Right => { app.move_right(); }
+                    KeyCode::Left => {
+                        app.move_left();
+                    }
+                    KeyCode::Right => {
+                        app.move_right();
+                    }
                     KeyCode::Home => {
                         let disp = app.display_cursor();
                         let disp_start = visual_line_start(disp, app.input_inner_width);
@@ -1194,12 +1399,20 @@ async fn run_loop(
                     }
                     // shift+up/down/pgup/pgdown scroll chat; must appear before plain Up/Down
                     KeyCode::Up if key.modifiers.contains(KeyModifiers::SHIFT) => {
-                        let current = if app.chat_pinned { app.chat_max_scroll } else { app.chat_scroll };
+                        let current = if app.chat_pinned {
+                            app.chat_max_scroll
+                        } else {
+                            app.chat_scroll
+                        };
                         app.chat_pinned = false;
                         app.chat_scroll = current.saturating_sub(3);
                     }
                     KeyCode::Down if key.modifiers.contains(KeyModifiers::SHIFT) => {
-                        let current = if app.chat_pinned { app.chat_max_scroll } else { app.chat_scroll };
+                        let current = if app.chat_pinned {
+                            app.chat_max_scroll
+                        } else {
+                            app.chat_scroll
+                        };
                         let next = current.saturating_add(3);
                         if next >= app.chat_max_scroll {
                             app.chat_pinned = true;
@@ -1209,12 +1422,20 @@ async fn run_loop(
                         }
                     }
                     KeyCode::PageUp => {
-                        let current = if app.chat_pinned { app.chat_max_scroll } else { app.chat_scroll };
+                        let current = if app.chat_pinned {
+                            app.chat_max_scroll
+                        } else {
+                            app.chat_scroll
+                        };
                         app.chat_pinned = false;
                         app.chat_scroll = current.saturating_sub(10);
                     }
                     KeyCode::PageDown => {
-                        let current = if app.chat_pinned { app.chat_max_scroll } else { app.chat_scroll };
+                        let current = if app.chat_pinned {
+                            app.chat_max_scroll
+                        } else {
+                            app.chat_scroll
+                        };
                         let next = current.saturating_add(10);
                         if next >= app.chat_max_scroll {
                             app.chat_pinned = true;
@@ -1225,7 +1446,8 @@ async fn run_loop(
                     }
                     KeyCode::Up => {
                         if app.autocomplete_visible && !app.autocomplete_items.is_empty() {
-                            app.autocomplete_selected = app.autocomplete_selected
+                            app.autocomplete_selected = app
+                                .autocomplete_selected
                                 .checked_sub(1)
                                 .unwrap_or(app.autocomplete_items.len() - 1);
                         } else if !app.input_history.is_empty() {
@@ -1269,96 +1491,121 @@ async fn run_loop(
                 }
             }
 
-            TuiEvent::Mouse(ev) => {
-                match ev.kind {
-                    MouseEventKind::Down(MouseButton::Left) => {
-                        if in_rect(ev.column, ev.row, app.chat_area) {
-                            match screen_to_chat_pos(ev.column, ev.row, app) {
-                                Some(pos) => {
-                                    app.selection = Some(Selection {
-                                        target: SelectionTarget::Chat,
-                                        anchor: pos,
-                                        extent: pos,
-                                    });
-                                }
-                                None => { app.selection = None; }
+            TuiEvent::Mouse(ev) => match ev.kind {
+                MouseEventKind::Down(MouseButton::Left) => {
+                    if in_rect(ev.column, ev.row, app.chat_area) {
+                        match screen_to_chat_pos(ev.column, ev.row, app) {
+                            Some(pos) => {
+                                app.selection = Some(Selection {
+                                    target: SelectionTarget::Chat,
+                                    anchor: pos,
+                                    extent: pos,
+                                });
                             }
-                        } else if app.tools_visible && in_rect(ev.column, ev.row, app.tools_area) {
-                            match screen_to_tools_row(ev.row, app) {
-                                Some(row_idx) => {
-                                    app.selection = Some(Selection {
-                                        target: SelectionTarget::Tools,
-                                        anchor: ChatPos { line_idx: row_idx, col: 0 },
-                                        extent: ChatPos { line_idx: row_idx, col: usize::MAX },
-                                    });
-                                }
-                                None => { app.selection = None; }
-                            }
-                        } else {
-                            app.selection = None;
-                        }
-                    }
-                    MouseEventKind::Drag(MouseButton::Left) => {
-                        if in_rect(ev.column, ev.row, app.chat_area) {
-                            let is_chat_sel = matches!(&app.selection, Some(s) if s.target == SelectionTarget::Chat);
-                            if is_chat_sel {
-                                let pos = screen_to_chat_pos(ev.column, ev.row, app);
-                                if let (Some(pos), Some(ref mut sel)) = (pos, app.selection.as_mut()) {
-                                    sel.extent = pos;
-                                }
-                            }
-                        }
-                    }
-                    MouseEventKind::Up(MouseButton::Left) => {
-                        if let Some(ref sel) = app.selection {
-                            if sel.anchor == sel.extent {
+                            None => {
                                 app.selection = None;
                             }
                         }
-                    }
-                    MouseEventKind::ScrollUp => {
-                        if in_rect(ev.column, ev.row, app.chat_area) {
-                            let current = if app.chat_pinned { app.chat_max_scroll } else { app.chat_scroll };
-                            app.chat_pinned = false;
-                            app.chat_scroll = current.saturating_sub(3);
-                        } else if app.tools_visible && in_rect(ev.column, ev.row, app.tools_area) {
-                            let current = if app.tools_pinned { app.tools_max_scroll } else { app.tools_scroll };
-                            app.tools_pinned = false;
-                            app.tools_scroll = current.saturating_sub(1);
-                        }
-                    }
-                    MouseEventKind::ScrollDown => {
-                        if in_rect(ev.column, ev.row, app.chat_area) {
-                            let current = if app.chat_pinned { app.chat_max_scroll } else { app.chat_scroll };
-                            let next = current.saturating_add(3);
-                            if next >= app.chat_max_scroll {
-                                app.chat_pinned = true;
-                            } else {
-                                app.chat_scroll = next;
+                    } else if app.tools_visible && in_rect(ev.column, ev.row, app.tools_area) {
+                        match screen_to_tools_row(ev.row, app) {
+                            Some(row_idx) => {
+                                app.selection = Some(Selection {
+                                    target: SelectionTarget::Tools,
+                                    anchor: ChatPos {
+                                        line_idx: row_idx,
+                                        col: 0,
+                                    },
+                                    extent: ChatPos {
+                                        line_idx: row_idx,
+                                        col: usize::MAX,
+                                    },
+                                });
                             }
-                        } else if app.tools_visible && in_rect(ev.column, ev.row, app.tools_area) {
-                            let current = if app.tools_pinned { app.tools_max_scroll } else { app.tools_scroll };
-                            let next = current.saturating_add(1);
-                            if next >= app.tools_max_scroll {
-                                app.tools_pinned = true;
-                            } else {
-                                app.tools_scroll = next;
+                            None => {
+                                app.selection = None;
                             }
                         }
+                    } else {
+                        app.selection = None;
                     }
-                    _ => {}
                 }
-            }
+                MouseEventKind::Drag(MouseButton::Left) => {
+                    if in_rect(ev.column, ev.row, app.chat_area) {
+                        let is_chat_sel =
+                            matches!(&app.selection, Some(s) if s.target == SelectionTarget::Chat);
+                        if is_chat_sel {
+                            let pos = screen_to_chat_pos(ev.column, ev.row, app);
+                            if let (Some(pos), Some(ref mut sel)) = (pos, app.selection.as_mut()) {
+                                sel.extent = pos;
+                            }
+                        }
+                    }
+                }
+                MouseEventKind::Up(MouseButton::Left) => {
+                    if let Some(ref sel) = app.selection {
+                        if sel.anchor == sel.extent {
+                            app.selection = None;
+                        }
+                    }
+                }
+                MouseEventKind::ScrollUp => {
+                    if in_rect(ev.column, ev.row, app.chat_area) {
+                        let current = if app.chat_pinned {
+                            app.chat_max_scroll
+                        } else {
+                            app.chat_scroll
+                        };
+                        app.chat_pinned = false;
+                        app.chat_scroll = current.saturating_sub(3);
+                    } else if app.tools_visible && in_rect(ev.column, ev.row, app.tools_area) {
+                        let current = if app.tools_pinned {
+                            app.tools_max_scroll
+                        } else {
+                            app.tools_scroll
+                        };
+                        app.tools_pinned = false;
+                        app.tools_scroll = current.saturating_sub(1);
+                    }
+                }
+                MouseEventKind::ScrollDown => {
+                    if in_rect(ev.column, ev.row, app.chat_area) {
+                        let current = if app.chat_pinned {
+                            app.chat_max_scroll
+                        } else {
+                            app.chat_scroll
+                        };
+                        let next = current.saturating_add(3);
+                        if next >= app.chat_max_scroll {
+                            app.chat_pinned = true;
+                        } else {
+                            app.chat_scroll = next;
+                        }
+                    } else if app.tools_visible && in_rect(ev.column, ev.row, app.tools_area) {
+                        let current = if app.tools_pinned {
+                            app.tools_max_scroll
+                        } else {
+                            app.tools_scroll
+                        };
+                        let next = current.saturating_add(1);
+                        if next >= app.tools_max_scroll {
+                            app.tools_pinned = true;
+                        } else {
+                            app.tools_scroll = next;
+                        }
+                    }
+                }
+                _ => {}
+            },
 
-            TuiEvent::SubmitResult(result) => {
-                match result {
-                    Ok(run_id) => { app.current_run_id = Some(run_id); }
-                    Err(e) => {
-                        app.last_error = Some(e.clone());
-                        app.chat.push(ChatMessage::System(format!("error: {e}")));
-                    }
+            TuiEvent::SubmitResult(result) => match result {
+                Ok(run_id) => {
+                    app.current_run_id = Some(run_id);
                 }
-            }
+                Err(e) => {
+                    app.last_error = Some(e.clone());
+                    app.chat.push(ChatMessage::System(format!("error: {e}")));
+                }
+            },
 
             TuiEvent::Agent(ev) => {
                 app.handle_agent_event(ev);
@@ -1370,7 +1617,8 @@ async fn run_loop(
                             app.last_error = Some(e.clone());
                             app.chat.push(ChatMessage::System(format!("WS error: {e}")));
                         } else {
-                            app.chat.push(ChatMessage::System("disconnected from gateway".into()));
+                            app.chat
+                                .push(ChatMessage::System("disconnected from gateway".into()));
                         }
                         ws_client = None;
                         if !app.reconnecting {
@@ -1382,9 +1630,16 @@ async fn run_loop(
                                 let mut backoff = Duration::from_millis(250);
                                 loop {
                                     tokio::time::sleep(backoff).await;
-                                    match WsClient::connect(&gateway_url, auth_token.clone(), tx.clone()).await {
+                                    match WsClient::connect(
+                                        &gateway_url,
+                                        auth_token.clone(),
+                                        tx.clone(),
+                                    )
+                                    .await
+                                    {
                                         Ok(client) => {
-                                            let _ = tx.send(TuiEvent::Reconnected(Ok(client))).await;
+                                            let _ =
+                                                tx.send(TuiEvent::Reconnected(Ok(client))).await;
                                             return;
                                         }
                                         Err(e) => {
@@ -1414,7 +1669,10 @@ async fn run_loop(
                         ws_client = Some(client);
                         app.reconnecting = false;
                         app.ws_status = WsStatus::Connected;
-                        app.chat.push(ChatMessage::System(format!("reconnected to {}", app.gateway_url)));
+                        app.chat.push(ChatMessage::System(format!(
+                            "reconnected to {}",
+                            app.gateway_url
+                        )));
                     }
                     Err(_) => {
                         // reconnect task is still running with backoff, nothing to do here
@@ -1433,7 +1691,8 @@ async fn run_loop(
                         app.chat.push(ChatMessage::System(msg));
                     }
                     Err(e) => {
-                        app.chat.push(ChatMessage::System(format!("command error: {e}")));
+                        app.chat
+                            .push(ChatMessage::System(format!("command error: {e}")));
                     }
                 }
                 app.run_phase = None;

--- a/apps/kelvin-tui/src/commands/mod.rs
+++ b/apps/kelvin-tui/src/commands/mod.rs
@@ -178,7 +178,11 @@ impl MergedCommandRegistry {
         if let Some((cmd, _)) = self.local.iter().find(|(_, item)| item.name == lower) {
             return Some(SlashCommand::Local(cmd.clone()));
         }
-        if self.remote.iter().any(|r| r.name.to_ascii_lowercase() == lower) {
+        if self
+            .remote
+            .iter()
+            .any(|r| r.name.to_ascii_lowercase() == lower)
+        {
             return Some(SlashCommand::Remote { name: lower });
         }
         None
@@ -193,10 +197,17 @@ impl MergedCommandRegistry {
                 .as_deref()
                 .map(|u| format!(" {u}"))
                 .unwrap_or_default();
-            lines.push(format!("  • /{}{} — {}", item.name, usage, item.description));
+            lines.push(format!(
+                "  • /{}{} — {}",
+                item.name, usage, item.description
+            ));
         }
         for r in &self.remote {
-            let usage = r.usage.as_deref().map(|u| format!(" {u}")).unwrap_or_default();
+            let usage = r
+                .usage
+                .as_deref()
+                .map(|u| format!(" {u}"))
+                .unwrap_or_default();
             lines.push(format!("  • /{}{} — {}", r.name, usage, r.description));
         }
         lines.join("\n")
@@ -253,7 +264,10 @@ mod tests {
     fn resolve_local_session() {
         let reg = MergedCommandRegistry::default();
         let cmd = reg.resolve("session");
-        assert!(matches!(cmd, Some(SlashCommand::Local(LocalCommand::Session))));
+        assert!(matches!(
+            cmd,
+            Some(SlashCommand::Local(LocalCommand::Session))
+        ));
     }
 
     #[test]

--- a/apps/kelvin-tui/src/main.rs
+++ b/apps/kelvin-tui/src/main.rs
@@ -38,7 +38,11 @@ fn parse_args() -> Result<CliConfig, String> {
         }
     }
 
-    Ok(CliConfig { gateway_url, auth_token, session_id })
+    Ok(CliConfig {
+        gateway_url,
+        auth_token,
+        session_id,
+    })
 }
 
 #[tokio::main]

--- a/apps/kelvin-tui/src/ui/autocomplete.rs
+++ b/apps/kelvin-tui/src/ui/autocomplete.rs
@@ -1,9 +1,9 @@
 use ratatui::{
-    Frame,
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, ListState},
+    Frame,
 };
 
 use crate::app::App;
@@ -57,7 +57,10 @@ pub fn render(f: &mut Frame, app: &App, input_area: Rect) {
                 Style::default().fg(Color::White)
             };
             let label = Line::from(vec![
-                Span::styled(format!("/{}", item.name), style.add_modifier(Modifier::BOLD)),
+                Span::styled(
+                    format!("/{}", item.name),
+                    style.add_modifier(Modifier::BOLD),
+                ),
                 Span::styled(
                     format!("  {}", item.description),
                     style.remove_modifier(Modifier::BOLD),

--- a/apps/kelvin-tui/src/ui/chat.rs
+++ b/apps/kelvin-tui/src/ui/chat.rs
@@ -1,9 +1,9 @@
 use ratatui::{
-    Frame,
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span, Text},
     widgets::{Block, Borders, Paragraph, Wrap},
+    Frame,
 };
 use unicode_width::UnicodeWidthChar;
 
@@ -23,20 +23,38 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
 
     for (i, msg) in app.chat.iter().enumerate() {
         if i > 0 {
-            lines.push(Line::from(Span::styled(sep_str.clone(), Style::default().fg(Color::DarkGray))));
-            line_info.push(ChatLineInfo { prefix_width: inner_width, is_separator: true });
+            lines.push(Line::from(Span::styled(
+                sep_str.clone(),
+                Style::default().fg(Color::DarkGray),
+            )));
+            line_info.push(ChatLineInfo {
+                prefix_width: inner_width,
+                is_separator: true,
+            });
             line_texts.push(String::new());
             // blank spacer line between messages
             lines.push(Line::from(vec![]));
-            line_info.push(ChatLineInfo { prefix_width: 0, is_separator: false });
+            line_info.push(ChatLineInfo {
+                prefix_width: 0,
+                is_separator: false,
+            });
             line_texts.push(String::new());
         }
         match msg {
             ChatMessage::User(text) => {
                 let all_lines: Vec<&str> = text.lines().collect();
-                let src_lines: Vec<&str> = if all_lines.is_empty() { vec![""] } else {
-                    let f: Vec<&str> = all_lines.into_iter().filter(|l| !l.trim().is_empty()).collect();
-                    if f.is_empty() { vec![""] } else { f }
+                let src_lines: Vec<&str> = if all_lines.is_empty() {
+                    vec![""]
+                } else {
+                    let f: Vec<&str> = all_lines
+                        .into_iter()
+                        .filter(|l| !l.trim().is_empty())
+                        .collect();
+                    if f.is_empty() {
+                        vec![""]
+                    } else {
+                        f
+                    }
                 };
                 let mut first = true;
                 for src_line in src_lines {
@@ -50,15 +68,27 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
                     };
                     first = false;
                     lines.push(line);
-                    line_info.push(ChatLineInfo { prefix_width: 2, is_separator: false });
+                    line_info.push(ChatLineInfo {
+                        prefix_width: 2,
+                        is_separator: false,
+                    });
                     line_texts.push(src_line.to_string());
                 }
             }
             ChatMessage::Assistant { text, .. } => {
                 let all_lines: Vec<&str> = text.lines().collect();
-                let src_lines: Vec<&str> = if all_lines.is_empty() { vec![""] } else {
-                    let f: Vec<&str> = all_lines.into_iter().filter(|l| !l.trim().is_empty()).collect();
-                    if f.is_empty() { vec![""] } else { f }
+                let src_lines: Vec<&str> = if all_lines.is_empty() {
+                    vec![""]
+                } else {
+                    let f: Vec<&str> = all_lines
+                        .into_iter()
+                        .filter(|l| !l.trim().is_empty())
+                        .collect();
+                    if f.is_empty() {
+                        vec![""]
+                    } else {
+                        f
+                    }
                 };
                 let mut first = true;
                 for src_line in src_lines {
@@ -72,17 +102,29 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
                     };
                     first = false;
                     lines.push(line);
-                    line_info.push(ChatLineInfo { prefix_width: 2, is_separator: false });
+                    line_info.push(ChatLineInfo {
+                        prefix_width: 2,
+                        is_separator: false,
+                    });
                     line_texts.push(src_line.to_string());
                 }
             }
             ChatMessage::System(text) => {
-                let style = Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC);
+                let style = Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::ITALIC);
                 let src_lines: Vec<&str> = text.lines().collect();
-                let src_lines = if src_lines.is_empty() { vec![""] } else { src_lines };
+                let src_lines = if src_lines.is_empty() {
+                    vec![""]
+                } else {
+                    src_lines
+                };
                 for src_line in src_lines {
                     lines.push(Line::from(Span::styled(src_line.to_string(), style)));
-                    line_info.push(ChatLineInfo { prefix_width: 0, is_separator: false });
+                    line_info.push(ChatLineInfo {
+                        prefix_width: 0,
+                        is_separator: false,
+                    });
                     line_texts.push(src_line.to_string());
                 }
             }
@@ -90,8 +132,14 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
     }
 
     if !app.chat.is_empty() {
-        lines.push(Line::from(Span::styled(sep_str, Style::default().fg(Color::DarkGray))));
-        line_info.push(ChatLineInfo { prefix_width: inner_width, is_separator: true });
+        lines.push(Line::from(Span::styled(
+            sep_str,
+            Style::default().fg(Color::DarkGray),
+        )));
+        line_info.push(ChatLineInfo {
+            prefix_width: inner_width,
+            is_separator: true,
+        });
         line_texts.push(String::new());
     }
 
@@ -99,7 +147,11 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
     let mut line_map: Vec<(usize, usize)> = Vec::with_capacity(lines.len());
     for (idx, line) in lines.iter().enumerate() {
         let w = line.width();
-        let vrows = if inner_width == 0 || w == 0 { 1 } else { w.div_ceil(inner_width) };
+        let vrows = if inner_width == 0 || w == 0 {
+            1
+        } else {
+            w.div_ceil(inner_width)
+        };
         for sub in 0..vrows {
             line_map.push((idx, sub * inner_width));
         }
@@ -129,14 +181,22 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
 
     // --- Render ---
     let paragraph = Paragraph::new(Text::from(lines))
-        .block(Block::default().borders(Borders::ALL).title(" Chat (drag to select · ^C copy · PgUp/PgDn scroll) "))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Chat (drag to select · ^C copy · PgUp/PgDn scroll) "),
+        )
         .wrap(Wrap { trim: false });
 
     let total_visual_lines = paragraph.line_count(inner_width as u16);
     let max_scroll = total_visual_lines.saturating_sub(inner_height);
     app.chat_max_scroll = max_scroll;
 
-    let scroll = if app.chat_pinned { max_scroll } else { app.chat_scroll.min(max_scroll) };
+    let scroll = if app.chat_pinned {
+        max_scroll
+    } else {
+        app.chat_scroll.min(max_scroll)
+    };
     f.render_widget(paragraph.scroll((scroll as u16, 0)), area);
 }
 
@@ -145,7 +205,8 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
 fn apply_highlight(line: Line<'static>, sel_start: usize, sel_end: usize) -> Line<'static> {
     let spans = if sel_start == 0 && sel_end == usize::MAX {
         // Whole line selected — apply bg to every span
-        line.spans.into_iter()
+        line.spans
+            .into_iter()
             .map(|s| Span::styled(s.content.into_owned(), s.style.bg(HL_BG)))
             .collect()
     } else {
@@ -155,7 +216,11 @@ fn apply_highlight(line: Line<'static>, sel_start: usize, sel_end: usize) -> Lin
 }
 
 /// Split spans, applying HL_BG to the [sel_start, sel_end) display-column range.
-fn split_with_highlight(spans: Vec<Span<'static>>, sel_start: usize, sel_end: usize) -> Vec<Span<'static>> {
+fn split_with_highlight(
+    spans: Vec<Span<'static>>,
+    sel_start: usize,
+    sel_end: usize,
+) -> Vec<Span<'static>> {
     let mut result: Vec<Span<'static>> = Vec::new();
     let mut offset = 0usize; // cumulative display width
 
@@ -171,9 +236,15 @@ fn split_with_highlight(spans: Vec<Span<'static>>, sel_start: usize, sel_end: us
             let local_end = sel_end.min(span_end) - offset;
             let (before, rest) = split_at_col(&content, local_start);
             let (mid, after) = split_at_col(rest, local_end - local_start);
-            if !before.is_empty() { result.push(Span::styled(before.to_string(), span.style)); }
-            if !mid.is_empty()    { result.push(Span::styled(mid.to_string(), span.style.bg(HL_BG))); }
-            if !after.is_empty()  { result.push(Span::styled(after.to_string(), span.style)); }
+            if !before.is_empty() {
+                result.push(Span::styled(before.to_string(), span.style));
+            }
+            if !mid.is_empty() {
+                result.push(Span::styled(mid.to_string(), span.style.bg(HL_BG)));
+            }
+            if !after.is_empty() {
+                result.push(Span::styled(after.to_string(), span.style));
+            }
         }
         offset = span_end;
     }
@@ -189,7 +260,9 @@ fn span_display_width(s: &str) -> usize {
 fn split_at_col(s: &str, col: usize) -> (&str, &str) {
     let mut width = 0usize;
     for (byte_idx, ch) in s.char_indices() {
-        if width >= col { return (&s[..byte_idx], &s[byte_idx..]); }
+        if width >= col {
+            return (&s[..byte_idx], &s[byte_idx..]);
+        }
         width += ch.width().unwrap_or(0);
     }
     (s, "")

--- a/apps/kelvin-tui/src/ui/input.rs
+++ b/apps/kelvin-tui/src/ui/input.rs
@@ -1,9 +1,9 @@
 use ratatui::{
-    Frame,
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span, Text},
     widgets::{Block, Borders, Paragraph},
+    Frame,
 };
 
 use crate::app::{App, PasteMarker};
@@ -33,15 +33,21 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
         let mut offset = first_cap;
         while offset < display.len() {
             let end = (offset + inner_width).min(display.len());
-            lines.push(Line::from(
-                render_display_spans(&display, &app.paste_markers, offset, end),
-            ));
+            lines.push(Line::from(render_display_spans(
+                &display,
+                &app.paste_markers,
+                offset,
+                end,
+            )));
             offset += inner_width;
         }
     }
 
-    let paragraph = Paragraph::new(Text::from(lines))
-        .block(Block::default().borders(Borders::ALL).title(" Input (Enter=submit, ^C^C=quit) "));
+    let paragraph = Paragraph::new(Text::from(lines)).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(" Input (Enter=submit, ^C^C=quit) "),
+    );
 
     f.render_widget(paragraph, area);
 

--- a/apps/kelvin-tui/src/ui/mod.rs
+++ b/apps/kelvin-tui/src/ui/mod.rs
@@ -1,6 +1,6 @@
 use ratatui::{
-    Frame,
     layout::{Constraint, Direction, Layout},
+    Frame,
 };
 
 use crate::app::App;
@@ -24,7 +24,7 @@ fn input_line_count(input: &str, inner_width: u16) -> u16 {
     } else {
         let rest = input.len() - first_cap;
         let subsequent = rest.div_ceil(inner_width as usize);
-        (1 + subsequent).min(5) as u16  // cap at 5 content lines
+        (1 + subsequent).min(5) as u16 // cap at 5 content lines
     }
 }
 

--- a/apps/kelvin-tui/src/ui/status.rs
+++ b/apps/kelvin-tui/src/ui/status.rs
@@ -1,11 +1,11 @@
 use std::time::{Duration, Instant};
 
 use ratatui::{
-    Frame,
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::Paragraph,
+    Frame,
 };
 
 use crate::app::{App, LifecyclePhase, WsStatus};
@@ -29,9 +29,9 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let error_str = app.last_error.as_deref().unwrap_or("");
 
     // Show exit hint if first ^C was pressed recently (within the 500ms window)
-    let show_exit_hint = app
-        .last_ctrl_c
-        .map_or(false, |t| Instant::now().duration_since(t) < Duration::from_secs(5));
+    let show_exit_hint = app.last_ctrl_c.map_or(false, |t| {
+        Instant::now().duration_since(t) < Duration::from_secs(5)
+    });
 
     let mut spans = vec![
         Span::raw(format!(" {} ", app.gateway_url)),
@@ -51,19 +51,24 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     ];
 
     spans.push(Span::styled(
-        if app.tools_visible { "  ^T hide tools" } else { "  ^T show tools" },
+        if app.tools_visible {
+            "  ^T hide tools"
+        } else {
+            "  ^T show tools"
+        },
         Style::default().fg(Color::DarkGray),
     ));
 
     if show_exit_hint {
         spans.push(Span::styled(
             "  ^C again to exit",
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
         ));
     }
 
-    let paragraph = Paragraph::new(Line::from(spans))
-        .style(Style::default().bg(Color::DarkGray));
+    let paragraph = Paragraph::new(Line::from(spans)).style(Style::default().bg(Color::DarkGray));
 
     f.render_widget(paragraph, area);
 }

--- a/apps/kelvin-tui/src/ui/tools.rs
+++ b/apps/kelvin-tui/src/ui/tools.rs
@@ -1,43 +1,55 @@
 use ratatui::{
-    Frame,
     layout::{Constraint, Rect},
     style::{Color, Modifier, Style},
     text::Span,
     widgets::{Block, Borders, Row, Table, TableState},
+    Frame,
 };
 
 use crate::app::{App, SelectionTarget, ToolPhase};
 
 pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
-    let selected_row = app.selection.as_ref()
+    let selected_row = app
+        .selection
+        .as_ref()
         .filter(|s| s.target == SelectionTarget::Tools)
         .map(|s| s.anchor.line_idx);
 
-    let rows: Vec<Row> = app.tools.iter().enumerate().map(|(idx, entry)| {
-        let (phase_str, phase_color) = match entry.phase {
-            ToolPhase::Start => ("running", Color::Yellow),
-            ToolPhase::End => ("done", Color::Green),
-            ToolPhase::Error => ("error", Color::Red),
-        };
+    let rows: Vec<Row> = app
+        .tools
+        .iter()
+        .enumerate()
+        .map(|(idx, entry)| {
+            let (phase_str, phase_color) = match entry.phase {
+                ToolPhase::Start => ("running", Color::Yellow),
+                ToolPhase::End => ("done", Color::Green),
+                ToolPhase::Error => ("error", Color::Red),
+            };
 
-        let duration = match entry.ended_ms {
-            Some(end) => format!("{}ms", end.saturating_sub(entry.started_ms)),
-            None => "…".to_string(),
-        };
+            let duration = match entry.ended_ms {
+                Some(end) => format!("{}ms", end.saturating_sub(entry.started_ms)),
+                None => "…".to_string(),
+            };
 
-        let row = Row::new(vec![
-            ratatui::text::Text::from(Span::raw(entry.tool_name.clone())),
-            ratatui::text::Text::from(Span::styled(phase_str, Style::default().fg(phase_color).add_modifier(Modifier::BOLD))),
-            ratatui::text::Text::from(Span::raw(entry.summary.clone().unwrap_or_default())),
-            ratatui::text::Text::from(Span::raw(duration)),
-        ]);
+            let row = Row::new(vec![
+                ratatui::text::Text::from(Span::raw(entry.tool_name.clone())),
+                ratatui::text::Text::from(Span::styled(
+                    phase_str,
+                    Style::default()
+                        .fg(phase_color)
+                        .add_modifier(Modifier::BOLD),
+                )),
+                ratatui::text::Text::from(Span::raw(entry.summary.clone().unwrap_or_default())),
+                ratatui::text::Text::from(Span::raw(duration)),
+            ]);
 
-        if selected_row == Some(idx) {
-            row.style(Style::default().bg(Color::Indexed(238)))
-        } else {
-            row
-        }
-    }).collect();
+            if selected_row == Some(idx) {
+                row.style(Style::default().bg(Color::Indexed(238)))
+            } else {
+                row
+            }
+        })
+        .collect();
 
     // 2 borders + 1 header row
     let inner_height = area.height.saturating_sub(3) as usize;
@@ -49,14 +61,19 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
         app.tools_scroll.min(app.tools_max_scroll)
     };
 
-    let table = Table::new(rows, [
-        Constraint::Percentage(30),
-        Constraint::Percentage(10),
-        Constraint::Percentage(45),
-        Constraint::Percentage(15),
-    ])
-    .header(Row::new(vec!["Tool", "Phase", "Summary", "Duration"])
-        .style(Style::default().add_modifier(Modifier::UNDERLINED)))
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Percentage(30),
+            Constraint::Percentage(10),
+            Constraint::Percentage(45),
+            Constraint::Percentage(15),
+        ],
+    )
+    .header(
+        Row::new(vec!["Tool", "Phase", "Summary", "Duration"])
+            .style(Style::default().add_modifier(Modifier::UNDERLINED)),
+    )
     .block(Block::default().borders(Borders::ALL).title(" Tools "));
 
     let mut state = TableState::default();

--- a/apps/kelvin-tui/src/ws_client.rs
+++ b/apps/kelvin-tui/src/ws_client.rs
@@ -46,7 +46,11 @@ pub struct WsClient {
 }
 
 impl WsClient {
-    pub async fn connect(url: &str, auth_token: Option<String>, tui_tx: mpsc::Sender<TuiEvent>) -> Result<Self, String> {
+    pub async fn connect(
+        url: &str,
+        auth_token: Option<String>,
+        tui_tx: mpsc::Sender<TuiEvent>,
+    ) -> Result<Self, String> {
         let (ws_stream, _) = timeout(Duration::from_secs(10), connect_async(url))
             .await
             .map_err(|_| "WebSocket connect timed out".to_string())?
@@ -63,7 +67,9 @@ impl WsClient {
         tokio::spawn(async move {
             while let Some(msg) = frame_rx.recv().await {
                 if ws_write.send(Message::Text(msg.into())).await.is_err() {
-                    let _ = tui_tx_writer.send(TuiEvent::WsStatus(WsStatus::Disconnected)).await;
+                    let _ = tui_tx_writer
+                        .send(TuiEvent::WsStatus(WsStatus::Disconnected))
+                        .await;
                     break;
                 }
             }
@@ -72,44 +78,57 @@ impl WsClient {
         tokio::spawn(async move {
             while let Some(msg) = ws_read.next().await {
                 match msg {
-                    Ok(Message::Text(text)) => {
-                        match serde_json::from_str::<ServerFrame>(&text) {
-                            Ok(ServerFrame::Res { id, ok, payload, error }) => {
-                                let result = if ok {
-                                    Ok(payload.unwrap_or(Value::Null))
-                                } else {
-                                    Err(error
-                                        .and_then(|e| e.get("message").and_then(|m| m.as_str()).map(|s| s.to_string()))
-                                        .unwrap_or_else(|| "unknown error".to_string()))
-                                };
-                                let mut map = pending_clone.lock().await;
-                                if let Some(tx) = map.remove(&id) {
-                                    let _ = tx.send(result);
-                                }
+                    Ok(Message::Text(text)) => match serde_json::from_str::<ServerFrame>(&text) {
+                        Ok(ServerFrame::Res {
+                            id,
+                            ok,
+                            payload,
+                            error,
+                        }) => {
+                            let result = if ok {
+                                Ok(payload.unwrap_or(Value::Null))
+                            } else {
+                                Err(error
+                                    .and_then(|e| {
+                                        e.get("message")
+                                            .and_then(|m| m.as_str())
+                                            .map(|s| s.to_string())
+                                    })
+                                    .unwrap_or_else(|| "unknown error".to_string()))
+                            };
+                            let mut map = pending_clone.lock().await;
+                            if let Some(tx) = map.remove(&id) {
+                                let _ = tx.send(result);
                             }
-                            Ok(ServerFrame::Event { event, payload }) => {
-                                if event == "agent" {
-                                    match serde_json::from_value::<AgentEvent>(payload) {
-                                        Ok(ev) => {
-                                            let _ = tui_tx_clone.send(TuiEvent::Agent(ev)).await;
-                                        }
-                                        Err(e) => {
-                                            let _ = tui_tx_clone.send(TuiEvent::WsStatus(
-                                                WsStatus::Error(format!("failed to parse agent event: {e}"))
-                                            )).await;
-                                        }
+                        }
+                        Ok(ServerFrame::Event { event, payload }) => {
+                            if event == "agent" {
+                                match serde_json::from_value::<AgentEvent>(payload) {
+                                    Ok(ev) => {
+                                        let _ = tui_tx_clone.send(TuiEvent::Agent(ev)).await;
+                                    }
+                                    Err(e) => {
+                                        let _ = tui_tx_clone
+                                            .send(TuiEvent::WsStatus(WsStatus::Error(format!(
+                                                "failed to parse agent event: {e}"
+                                            ))))
+                                            .await;
                                     }
                                 }
                             }
-                            Err(e) => {
-                                let _ = tui_tx_clone.send(TuiEvent::WsStatus(
-                                    WsStatus::Error(format!("failed to parse server frame: {e}"))
-                                )).await;
-                            }
                         }
-                    }
+                        Err(e) => {
+                            let _ = tui_tx_clone
+                                .send(TuiEvent::WsStatus(WsStatus::Error(format!(
+                                    "failed to parse server frame: {e}"
+                                ))))
+                                .await;
+                        }
+                    },
                     Ok(Message::Close(_)) | Err(_) => {
-                        let _ = tui_tx_clone.send(TuiEvent::WsStatus(WsStatus::Disconnected)).await;
+                        let _ = tui_tx_clone
+                            .send(TuiEvent::WsStatus(WsStatus::Disconnected))
+                            .await;
                         break;
                     }
                     _ => {}
@@ -148,7 +167,10 @@ impl WsClient {
             map.insert(id, tx);
         }
 
-        self.sender.send(text).await.map_err(|_| "sender closed".to_string())?;
+        self.sender
+            .send(text)
+            .await
+            .map_err(|_| "sender closed".to_string())?;
 
         match timeout(Duration::from_secs(30), rx).await {
             Ok(result) => result.map_err(|_| "response channel closed".to_string())?,

--- a/crates/kelvin-brain/src/installed_plugins.rs
+++ b/crates/kelvin-brain/src/installed_plugins.rs
@@ -931,9 +931,9 @@ fn validate_model_output_schema(value: &Value) -> Result<(), String> {
         .ok_or("field 'tool_calls' must be an array")?;
 
     for (idx, tool_call) in tool_calls_array.iter().enumerate() {
-        let tc_obj = tool_call.as_object().ok_or_else(|| {
-            format!("tool_calls[{idx}] is not a JSON object")
-        })?;
+        let tc_obj = tool_call
+            .as_object()
+            .ok_or_else(|| format!("tool_calls[{idx}] is not a JSON object"))?;
 
         let id = tc_obj
             .get("id")
@@ -987,20 +987,19 @@ fn validate_openai_response_schema(value: &Value) -> Result<(), String> {
         .get("output_text")
         .map(|v| v.is_string())
         .unwrap_or(false);
-    let has_output = obj
-        .get("output")
-        .map(|v| v.is_array())
-        .unwrap_or(false);
+    let has_output = obj.get("output").map(|v| v.is_array()).unwrap_or(false);
 
     if !has_output_text && !has_output {
-        return Err("OpenAI Responses: must have 'output_text' (string) or 'output' (array)".to_string());
+        return Err(
+            "OpenAI Responses: must have 'output_text' (string) or 'output' (array)".to_string(),
+        );
     }
 
     if let Some(output_array) = obj.get("output").and_then(Value::as_array) {
         for (idx, item) in output_array.iter().enumerate() {
-            let item_obj = item.as_object().ok_or_else(|| {
-                format!("OpenAI Responses output[{idx}] is not a JSON object")
-            })?;
+            let item_obj = item
+                .as_object()
+                .ok_or_else(|| format!("OpenAI Responses output[{idx}] is not a JSON object"))?;
 
             let item_type = item_obj
                 .get("type")
@@ -1010,7 +1009,9 @@ fn validate_openai_response_schema(value: &Value) -> Result<(), String> {
             match item_type {
                 "message" => {
                     let content = item_obj.get("content").ok_or_else(|| {
-                        format!("OpenAI Responses output[{idx}] (type=message) missing field: content")
+                        format!(
+                            "OpenAI Responses output[{idx}] (type=message) missing field: content"
+                        )
                     })?;
                     if !content.is_array() {
                         return Err(format!(
@@ -1049,16 +1050,14 @@ fn validate_anthropic_response_schema(value: &Value) -> Result<(), String> {
         .ok_or("Anthropic Messages: field 'content' must be an array")?;
 
     for (idx, block) in content_array.iter().enumerate() {
-        let block_obj = block.as_object().ok_or_else(|| {
-            format!("Anthropic Messages content[{idx}] is not a JSON object")
-        })?;
+        let block_obj = block
+            .as_object()
+            .ok_or_else(|| format!("Anthropic Messages content[{idx}] is not a JSON object"))?;
 
         let block_type = block_obj
             .get("type")
             .and_then(Value::as_str)
-            .ok_or_else(|| {
-                format!("Anthropic Messages content[{idx}] missing field: type")
-            })?;
+            .ok_or_else(|| format!("Anthropic Messages content[{idx}] missing field: type"))?;
 
         match block_type {
             "text" => {
@@ -1095,9 +1094,9 @@ fn validate_openai_chat_completions_schema(value: &Value) -> Result<(), String> 
     let choices = obj
         .get("choices")
         .ok_or("OpenAI Chat Completions: missing required field: choices")?;
-    let choices_array = choices.as_array().ok_or(
-        "OpenAI Chat Completions: field 'choices' must be an array",
-    )?;
+    let choices_array = choices
+        .as_array()
+        .ok_or("OpenAI Chat Completions: field 'choices' must be an array")?;
 
     if choices_array.is_empty() {
         return Err("OpenAI Chat Completions: choices array must not be empty".to_string());
@@ -1110,14 +1109,12 @@ fn validate_openai_chat_completions_schema(value: &Value) -> Result<(), String> 
     let message = first_choice
         .get("message")
         .ok_or("OpenAI Chat Completions: choices[0] missing field: message")?;
-    let message_obj = message.as_object().ok_or(
-        "OpenAI Chat Completions: choices[0].message must be a JSON object",
-    )?;
+    let message_obj = message
+        .as_object()
+        .ok_or("OpenAI Chat Completions: choices[0].message must be a JSON object")?;
 
     if !message_obj.contains_key("role") {
-        return Err(
-            "OpenAI Chat Completions: choices[0].message missing field: role".to_string(),
-        );
+        return Err("OpenAI Chat Completions: choices[0].message missing field: role".to_string());
     }
 
     if let Some(tool_calls) = message_obj.get("tool_calls") {
@@ -1176,7 +1173,11 @@ fn adapt_openai_response(value: &Value) -> Option<ModelOutput> {
                         .and_then(Value::as_str)
                         .and_then(|s| serde_json::from_str(s).ok())
                         .unwrap_or_else(|| serde_json::json!({}));
-                    tool_calls.push(ToolCall { id, name, arguments });
+                    tool_calls.push(ToolCall {
+                        id,
+                        name,
+                        arguments,
+                    });
                     continue;
                 }
                 if item_type != Some("message") {
@@ -1246,7 +1247,11 @@ fn adapt_anthropic_response(value: &Value) -> Option<ModelOutput> {
                     .get("input")
                     .cloned()
                     .unwrap_or_else(|| serde_json::json!({}));
-                tool_calls.push(ToolCall { id, name, arguments });
+                tool_calls.push(ToolCall {
+                    id,
+                    name,
+                    arguments,
+                });
             }
             _ => {}
         }
@@ -1295,7 +1300,11 @@ fn adapt_openrouter_response(value: &Value) -> Option<ModelOutput> {
     let mut tool_calls = Vec::new();
     if let Some(tc_array) = message.get("tool_calls").and_then(Value::as_array) {
         for tc in tc_array {
-            let id = tc.get("id").and_then(Value::as_str).unwrap_or("").to_string();
+            let id = tc
+                .get("id")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
             let function = tc.get("function");
             let name = function
                 .and_then(|f| f.get("name"))
@@ -1307,7 +1316,11 @@ fn adapt_openrouter_response(value: &Value) -> Option<ModelOutput> {
                 .and_then(Value::as_str)
                 .and_then(|s| serde_json::from_str(s).ok())
                 .unwrap_or_else(|| serde_json::json!({}));
-            tool_calls.push(ToolCall { id, name, arguments });
+            tool_calls.push(ToolCall {
+                id,
+                name,
+                arguments,
+            });
         }
     }
 
@@ -1724,10 +1737,7 @@ fn load_one_plugin(
 
         let tool_name = package_manifest.resolved_tool_name()?;
         let sandbox_policy = sandbox_from_manifest(&package_manifest)?;
-        let tool_description = package_manifest
-            .description
-            .clone()
-            .unwrap_or_default();
+        let tool_description = package_manifest.description.clone().unwrap_or_default();
         let tool_input_schema = package_manifest
             .tool_input_schema
             .clone()
@@ -3209,10 +3219,7 @@ mod schema_validation_tests {
             "status": "success"
         });
         let err = validate_openai_response_schema(&invalid).unwrap_err();
-        assert!(
-            err.contains("output_text") ||
-            err.contains("output")
-        );
+        assert!(err.contains("output_text") || err.contains("output"));
     }
 
     #[test]

--- a/crates/kelvin-brain/src/kelvin_brain.rs
+++ b/crates/kelvin-brain/src/kelvin_brain.rs
@@ -170,7 +170,7 @@ impl KelvinBrain {
                     AgentPayload {
                         text: summary,
                         is_error: true,
-                    }
+                    },
                 ));
                 continue;
             };
@@ -223,7 +223,7 @@ impl KelvinBrain {
                         AgentPayload {
                             text: summary,
                             is_error: true,
-                        }
+                        },
                     ));
                     continue;
                 }
@@ -281,7 +281,7 @@ impl KelvinBrain {
                     AgentPayload {
                         text: visible_text,
                         is_error: result.is_error,
-                    }
+                    },
                 ));
             }
         }
@@ -386,10 +386,7 @@ impl KelvinBrain {
             if !text.is_empty() && text != "NO_REPLY" {
                 self.emit_assistant(&req.run_id, &text, !has_tools).await?;
                 self.session_store
-                    .append_message(
-                        &req.session_id,
-                        SessionMessage::assistant(text.clone()),
-                    )
+                    .append_message(&req.session_id, SessionMessage::assistant(text.clone()))
                     .await?;
                 if !has_tools {
                     payloads.push(AgentPayload {
@@ -405,30 +402,37 @@ impl KelvinBrain {
 
             let tool_results = self.execute_tool_calls(&req, &output.tool_calls).await?;
 
-            let tool_calls: Vec<_> = tool_results.iter()
-                .map(|(tc,tp)| (tc.name.clone(), &tc.arguments, tp.is_error))
+            let tool_calls: Vec<_> = tool_results
+                .iter()
+                .map(|(tc, tp)| (tc.name.clone(), &tc.arguments, tp.is_error))
                 .collect();
 
             let loop_detection = loop_detector.record_call(&tool_calls);
 
-            payloads.extend(tool_results.into_iter().map(|(_,tc)| tc).collect::<Vec<_>>());
+            payloads.extend(
+                tool_results
+                    .into_iter()
+                    .map(|(_, tc)| tc)
+                    .collect::<Vec<_>>(),
+            );
             iteration += 1;
 
             let force_reason = if iteration >= max_iter {
                 Some(format!("max tool iterations ({max_iter}) reached"))
-            } else if let LoopDetectionResult::SuspectedLoop { tool_name, repeat_count, is_all_errors } = loop_detection {
+            } else if let LoopDetectionResult::SuspectedLoop {
+                tool_name,
+                repeat_count,
+                is_all_errors,
+            } = loop_detection
+            {
                 Some(format!("loop detector triggered with (name=\"{tool_name}\", repeat_count={repeat_count}, is_all_errors={is_all_errors})"))
             } else {
                 None
             };
 
             if let Some(reason) = force_reason {
-                self.emit_lifecycle(
-                    &req.run_id,
-                    LifecyclePhase::Warning,
-                    Some(reason),
-                )
-                .await?;
+                self.emit_lifecycle(&req.run_id, LifecyclePhase::Warning, Some(reason))
+                    .await?;
 
                 let final_history = self.session_store.history(&req.session_id).await?;
 

--- a/crates/kelvin-brain/src/lib.rs
+++ b/crates/kelvin-brain/src/lib.rs
@@ -1,8 +1,8 @@
 pub mod installed_plugins;
 pub mod kelvin_brain;
 pub mod providers;
-pub mod wasm_skill_tool;
 pub mod tool_loop_detector;
+pub mod wasm_skill_tool;
 
 pub use installed_plugins::{
     default_plugin_home, default_trust_policy_path, load_installed_plugins,

--- a/crates/kelvin-brain/src/tool_loop_detector.rs
+++ b/crates/kelvin-brain/src/tool_loop_detector.rs
@@ -112,11 +112,12 @@ mod tests {
         (name.to_string(), args, is_error)
     }
 
-    fn record(detector: &mut ToolLoopDetector, calls: &[(String, Value, bool)]) -> LoopDetectionResult {
-        let refs: Vec<(String, &Value, bool)> = calls
-            .iter()
-            .map(|(n, v, e)| (n.clone(), v, *e))
-            .collect();
+    fn record(
+        detector: &mut ToolLoopDetector,
+        calls: &[(String, Value, bool)],
+    ) -> LoopDetectionResult {
+        let refs: Vec<(String, &Value, bool)> =
+            calls.iter().map(|(n, v, e)| (n.clone(), v, *e)).collect();
         detector.record_call(&refs)
     }
 

--- a/crates/kelvin-brain/tests/core_contract_e2e.rs
+++ b/crates/kelvin-brain/tests/core_contract_e2e.rs
@@ -514,8 +514,16 @@ async fn e2e_multi_iteration_tool_calls() {
     let tool_calls_log = Arc::new(Mutex::new(Vec::<String>::new()));
 
     let tools = Arc::new(MapToolRegistry::from_tools(vec![
-        Arc::new(RecordingTool::new("alpha", "alpha-out", tool_calls_log.clone())),
-        Arc::new(RecordingTool::new("beta", "beta-out", tool_calls_log.clone())),
+        Arc::new(RecordingTool::new(
+            "alpha",
+            "alpha-out",
+            tool_calls_log.clone(),
+        )),
+        Arc::new(RecordingTool::new(
+            "beta",
+            "beta-out",
+            tool_calls_log.clone(),
+        )),
     ]));
 
     let model = Arc::new(MultiPhaseStubModelProvider::new(vec![
@@ -561,11 +569,20 @@ async fn e2e_multi_iteration_tool_calls() {
     // user → assistant1 → tool(alpha) → assistant2 → tool(beta) → assistant3
     assert_eq!(history.len(), 6);
     assert!(matches!(history[0].role, kelvin_core::SessionRole::User));
-    assert!(matches!(history[1].role, kelvin_core::SessionRole::Assistant));
+    assert!(matches!(
+        history[1].role,
+        kelvin_core::SessionRole::Assistant
+    ));
     assert!(matches!(history[2].role, kelvin_core::SessionRole::Tool));
-    assert!(matches!(history[3].role, kelvin_core::SessionRole::Assistant));
+    assert!(matches!(
+        history[3].role,
+        kelvin_core::SessionRole::Assistant
+    ));
     assert!(matches!(history[4].role, kelvin_core::SessionRole::Tool));
-    assert!(matches!(history[5].role, kelvin_core::SessionRole::Assistant));
+    assert!(matches!(
+        history[5].role,
+        kelvin_core::SessionRole::Assistant
+    ));
 }
 
 #[tokio::test]

--- a/crates/kelvin-sdk/src/lib.rs
+++ b/crates/kelvin-sdk/src/lib.rs
@@ -783,10 +783,7 @@ impl SessionStore for FileBackedSessionStore {
     }
 
     async fn clear_history(&self, session_id: &str) -> KelvinResult<()> {
-        self.messages
-            .write()
-            .await
-            .remove(session_id);
+        self.messages.write().await.remove(session_id);
         self.persistence.persist_session_messages(session_id, &[])
     }
 }
@@ -1140,8 +1137,14 @@ impl KelvinSdkRuntime {
             config.load_installed_plugins,
         )?;
         let brain = Arc::new(
-            KelvinBrain::new(session_store.clone(), memory, model, tools.clone(), event_sink)
-                .with_max_tool_iterations(config.max_tool_iterations),
+            KelvinBrain::new(
+                session_store.clone(),
+                memory,
+                model,
+                tools.clone(),
+                event_sink,
+            )
+            .with_max_tool_iterations(config.max_tool_iterations),
         );
         let runtime = CoreRuntime::new(brain);
         Ok(Self {

--- a/crates/kelvin-sdk/src/toolpack.rs
+++ b/crates/kelvin-sdk/src/toolpack.rs
@@ -505,7 +505,7 @@ impl Tool for SafeWebFetchTool {
                     "type": "integer",
                     "description": "Request timeout in milliseconds (100–30000). Defaults to 10000."
                 },
-                
+
                 "approval": {
                     "type": "object",
                     "description": "Approval object required for this sensitive operation.",

--- a/crates/kelvin-sdk/tests/tool_sandbox_nist_ai_rmf_1_0.rs
+++ b/crates/kelvin-sdk/tests/tool_sandbox_nist_ai_rmf_1_0.rs
@@ -96,7 +96,9 @@ async fn map_fs_write_allows_newlines_in_content() {
     )
     .await;
     assert!(
-        payloads.iter().any(|text| text.contains("fs_safe_write wrote")),
+        payloads
+            .iter()
+            .any(|text| text.contains("fs_safe_write wrote")),
         "expected write to succeed, got: {payloads:?}"
     );
     let text = std::fs::read_to_string(workspace.join("memory/lines.md")).expect("read output");
@@ -113,7 +115,9 @@ async fn map_fs_write_allows_tabs_and_mixed_control_chars_in_content() {
     )
     .await;
     assert!(
-        payloads.iter().any(|text| text.contains("fs_safe_write wrote")),
+        payloads
+            .iter()
+            .any(|text| text.contains("fs_safe_write wrote")),
         "expected write to succeed, got: {payloads:?}"
     );
     let text = std::fs::read_to_string(workspace.join("memory/tabbed.md")).expect("read output");

--- a/crates/kelvin-wasm/src/bin/kelvin-wasm-runner.rs
+++ b/crates/kelvin-wasm/src/bin/kelvin-wasm-runner.rs
@@ -59,9 +59,8 @@ fn run() -> Result<i32, String> {
                 let value = args
                     .get(idx + 1)
                     .ok_or_else(|| "missing value for --network-allow-hosts".to_string())?;
-                network_allow_hosts = Some(
-                    value.split(',').map(|h| h.trim().to_string()).collect(),
-                );
+                network_allow_hosts =
+                    Some(value.split(',').map(|h| h.trim().to_string()).collect());
                 idx += 2;
             }
             "--max-module-bytes" => {

--- a/crates/kelvin-wasm/src/lib.rs
+++ b/crates/kelvin-wasm/src/lib.rs
@@ -291,9 +291,7 @@ impl WasmSkillHost {
             let memory = instance
                 .get_memory(&mut store, claw_abi::EXPORT_MEMORY)
                 .ok_or_else(|| {
-                    KelvinError::InvalidInput(
-                        "v2 tool module must export memory".to_string(),
-                    )
+                    KelvinError::InvalidInput("v2 tool module must export memory".to_string())
                 })?;
             let alloc_fn = instance
                 .get_typed_func::<i32, i32>(&mut store, claw_abi::EXPORT_ALLOC)
@@ -302,23 +300,24 @@ impl WasmSkillHost {
                 .get_typed_func::<(i32, i32), ()>(&mut store, claw_abi::EXPORT_DEALLOC)
                 .map_err(|err| backend("resolve dealloc export", err))?;
             let handle_fn = instance
-                .get_typed_func::<(i32, i32), i64>(
-                    &mut store,
-                    claw_abi::HANDLE_TOOL_CALL,
-                )
+                .get_typed_func::<(i32, i32), i64>(&mut store, claw_abi::HANDLE_TOOL_CALL)
                 .map_err(|err| backend("resolve handle_tool_call export", err))?;
 
             let input_bytes = input_json.as_bytes();
             let input_len = i32::try_from(input_bytes.len()).map_err(|_| {
-                KelvinError::InvalidInput(
-                    "tool input exceeded i32 address space".to_string(),
-                )
+                KelvinError::InvalidInput("tool input exceeded i32 address space".to_string())
             })?;
 
             let input_ptr = alloc_fn
                 .call(&mut store, input_len)
                 .map_err(|err| backend("call alloc for tool input", err))?;
-            skill_write_guest_bytes(&memory, &mut store, input_ptr, input_bytes, "write tool input")?;
+            skill_write_guest_bytes(
+                &memory,
+                &mut store,
+                input_ptr,
+                input_bytes,
+                "write tool input",
+            )?;
 
             let call_result = handle_fn.call(&mut store, (input_ptr, input_len));
             let _ = dealloc_fn.call(&mut store, (input_ptr, input_len));
@@ -331,8 +330,7 @@ impl WasmSkillHost {
                 }
             })?;
 
-            let (output_ptr, output_len) =
-                skill_unpack_ptr_len(packed, "handle_tool_call return")?;
+            let (output_ptr, output_len) = skill_unpack_ptr_len(packed, "handle_tool_call return")?;
             let output_bytes = skill_read_guest_bytes(
                 &memory,
                 &mut store,
@@ -402,7 +400,11 @@ fn validate_imports(module: &Module, policy: &SandboxPolicy) -> KelvinResult<()>
             claw_abi::NETWORK_SEND if !policy.network_allow_hosts.is_empty() => {}
             claw_abi::HTTP_CALL if !policy.network_allow_hosts.is_empty() => {}
             claw_abi::GET_ENV if !policy.env_allow.is_empty() => {}
-            claw_abi::MOVE_SERVO | claw_abi::FS_READ | claw_abi::NETWORK_SEND | claw_abi::HTTP_CALL | claw_abi::GET_ENV => {
+            claw_abi::MOVE_SERVO
+            | claw_abi::FS_READ
+            | claw_abi::NETWORK_SEND
+            | claw_abi::HTTP_CALL
+            | claw_abi::GET_ENV => {
                 return Err(KelvinError::InvalidInput(format!(
                     "capability import '{name}' denied by sandbox policy"
                 )));
@@ -637,7 +639,10 @@ fn link_claw_imports(linker: &mut Linker<HostState>, policy: &SandboxPolicy) -> 
                         None => return 0,
                     };
                     let mut key_bytes = vec![0u8; key_len as usize];
-                    if memory.read(&caller, key_ptr as usize, &mut key_bytes).is_err() {
+                    if memory
+                        .read(&caller, key_ptr as usize, &mut key_bytes)
+                        .is_err()
+                    {
                         return 0;
                     }
                     let key = match std::str::from_utf8(&key_bytes) {
@@ -694,7 +699,9 @@ fn skill_read_guest_bytes(
     let mut bytes = vec![0_u8; len];
     memory
         .read(store, ptr as usize, &mut bytes)
-        .map_err(|err| KelvinError::InvalidInput(format!("{context}: memory read failed: {err}")))?;
+        .map_err(|err| {
+            KelvinError::InvalidInput(format!("{context}: memory read failed: {err}"))
+        })?;
     Ok(bytes)
 }
 
@@ -813,7 +820,10 @@ mod tests {
             SandboxPolicy::locked_down()
         );
         assert!(SandboxPreset::DevLocal.policy().allow_fs_read);
-        assert!(SandboxPreset::DevLocal.policy().network_allow_hosts.is_empty());
+        assert!(SandboxPreset::DevLocal
+            .policy()
+            .network_allow_hosts
+            .is_empty());
         assert!(SandboxPreset::HardwareControl.policy().allow_move_servo);
         assert!(!SandboxPreset::HardwareControl.policy().allow_fs_read);
     }
@@ -1050,7 +1060,10 @@ mod tests {
             .expect("v1 fallback");
         assert_eq!(result.output_json, None);
         assert_eq!(result.exit_code, 0);
-        assert_eq!(result.calls, vec![ClawCall::SendMessage { message_code: 42 }]);
+        assert_eq!(
+            result.calls,
+            vec![ClawCall::SendMessage { message_code: 42 }]
+        );
     }
 
     #[test]
@@ -1346,7 +1359,10 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&output).expect("valid json");
         // GitHub may redirect (301) or return 200; just verify a valid HTTP status came back
         let status = v["status"].as_u64().unwrap_or(0);
-        assert!(status > 0 && status < 600, "expected valid HTTP status, got {status}");
+        assert!(
+            status > 0 && status < 600,
+            "expected valid HTTP status, got {status}"
+        );
         assert!(!v["body"].as_str().unwrap_or("").is_empty());
     }
 }

--- a/crates/kelvin-wasm/src/model_host.rs
+++ b/crates/kelvin-wasm/src/model_host.rs
@@ -363,7 +363,9 @@ fn model_input_to_openai_chat_completions_request(input: &ModelInput, model_name
                 let mut schema = t.input_schema.clone();
                 // OpenAI requires `properties` on object schemas even when empty.
                 if schema.get("type").and_then(Value::as_str) == Some("object")
-                    && !schema.as_object().map_or(false, |o| o.contains_key("properties"))
+                    && !schema
+                        .as_object()
+                        .map_or(false, |o| o.contains_key("properties"))
                 {
                     schema["properties"] = json!({});
                 }
@@ -1092,7 +1094,9 @@ mod tests {
         assert_eq!(messages[2]["role"], Value::String("assistant".to_string()));
         assert_eq!(messages[2]["content"], Value::String("hi".to_string()));
         assert_eq!(messages[3]["role"], Value::String("user".to_string()));
-        let last_content = messages[3]["content"].as_str().expect("openrouter content string");
+        let last_content = messages[3]["content"]
+            .as_str()
+            .expect("openrouter content string");
         assert!(last_content.contains("Relevant memory"));
         assert!(last_content.contains("Project: KelvinClaw"));
         assert!(last_content.contains("Explain KelvinClaw."));


### PR DESCRIPTION
Running `cargo fmt --all` to fix 167 formatting violations across 22 source files. No logic changes — purely whitespace/import-order normalization.