### PR TITLE
fix: resolve all clippy warnings

### DIFF
--- a/apps/kelvin-tui/src/app.rs
+++ b/apps/kelvin-tui/src/app.rs
@@ -533,24 +533,23 @@ impl App {
                         started_ms: ts_ms,
                         ended_ms: None,
                     });
+                } else if let Some(entry) = self
+                    .tools
+                    .iter_mut()
+                    .rev()
+                    .find(|t| t.tool_name == tool_name && matches!(t.phase, ToolPhase::Start))
+                {
+                    entry.phase = phase;
+                    entry.summary = summary.or(entry.summary.clone());
+                    entry.ended_ms = Some(ts_ms);
                 } else {
-                    if let Some(entry) =
-                        self.tools.iter_mut().rev().find(|t| {
-                            t.tool_name == tool_name && matches!(t.phase, ToolPhase::Start)
-                        })
-                    {
-                        entry.phase = phase;
-                        entry.summary = summary.or(entry.summary.clone());
-                        entry.ended_ms = Some(ts_ms);
-                    } else {
-                        self.tools.push(ToolEntry {
-                            tool_name,
-                            phase,
-                            summary,
-                            started_ms: ts_ms,
-                            ended_ms: Some(ts_ms),
-                        });
-                    }
+                    self.tools.push(ToolEntry {
+                        tool_name,
+                        phase,
+                        summary,
+                        started_ms: ts_ms,
+                        ended_ms: Some(ts_ms),
+                    });
                 }
             }
             AgentEventData::Lifecycle {
@@ -715,7 +714,7 @@ fn copy_osc52(text: &str) {
 
 fn base64_encode(data: &[u8]) -> String {
     const T: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut out = String::with_capacity((data.len() + 2) / 3 * 4);
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
     for chunk in data.chunks(3) {
         let b0 = chunk[0] as u32;
         let b1 = chunk.get(1).copied().unwrap_or(0) as u32;
@@ -1085,9 +1084,10 @@ async fn run_loop(
                             app.selection = None;
                         } else {
                             let now = Instant::now();
-                            if app.last_ctrl_c.map_or(false, |t| {
-                                now.duration_since(t) < Duration::from_millis(500)
-                            }) {
+                            if app
+                                .last_ctrl_c
+                                .is_some_and(|t| now.duration_since(t) < Duration::from_millis(500))
+                            {
                                 app.should_quit = true;
                             } else {
                                 app.last_ctrl_c = Some(now);

--- a/apps/kelvin-tui/src/ui/chat.rs
+++ b/apps/kelvin-tui/src/ui/chat.rs
@@ -164,11 +164,12 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
             let n = lines.len();
             if start.line_idx < n {
                 let end_idx = end.line_idx.min(n - 1);
-                for idx in start.line_idx..=end_idx {
+                for (i, line) in lines[start.line_idx..=end_idx].iter_mut().enumerate() {
+                    let idx = i + start.line_idx;
                     let sel_start = if idx == start.line_idx { start.col } else { 0 };
                     let sel_end = if idx == end_idx { end.col } else { usize::MAX };
-                    let old = std::mem::replace(&mut lines[idx], Line::from(vec![]));
-                    lines[idx] = apply_highlight(old, sel_start, sel_end);
+                    let old = std::mem::replace(line, Line::from(vec![]));
+                    *line = apply_highlight(old, sel_start, sel_end);
                 }
             }
         }

--- a/apps/kelvin-tui/src/ui/status.rs
+++ b/apps/kelvin-tui/src/ui/status.rs
@@ -29,9 +29,9 @@ pub fn render(f: &mut Frame, app: &App, area: Rect) {
     let error_str = app.last_error.as_deref().unwrap_or("");
 
     // Show exit hint if first ^C was pressed recently (within the 500ms window)
-    let show_exit_hint = app.last_ctrl_c.map_or(false, |t| {
-        Instant::now().duration_since(t) < Duration::from_secs(5)
-    });
+    let show_exit_hint = app
+        .last_ctrl_c
+        .is_some_and(|t| Instant::now().duration_since(t) < Duration::from_secs(5));
 
     let mut spans = vec![
         Span::raw(format!(" {} ", app.gateway_url)),

--- a/apps/kelvin-tui/src/ws_client.rs
+++ b/apps/kelvin-tui/src/ws_client.rs
@@ -66,7 +66,7 @@ impl WsClient {
 
         tokio::spawn(async move {
             while let Some(msg) = frame_rx.recv().await {
-                if ws_write.send(Message::Text(msg.into())).await.is_err() {
+                if ws_write.send(Message::Text(msg)).await.is_err() {
                     let _ = tui_tx_writer
                         .send(TuiEvent::WsStatus(WsStatus::Disconnected))
                         .await;
@@ -176,7 +176,7 @@ impl WsClient {
             Ok(result) => result.map_err(|_| "response channel closed".to_string())?,
             Err(_) => {
                 self.pending.lock().await.remove(&id_for_cleanup);
-                return Err(format!("request '{method}' timed out"));
+                Err(format!("request '{method}' timed out"))
             }
         }
     }

--- a/crates/kelvin-memory-controller/src/bin/kelvin-memory-controller.rs
+++ b/crates/kelvin-memory-controller/src/bin/kelvin-memory-controller.rs
@@ -13,17 +13,13 @@ fn usage() -> &'static str {
 }
 
 fn handle_cli() -> Result<(), String> {
-    let mut args = std::env::args().skip(1);
-    while let Some(arg) = args.next() {
-        match arg.as_str() {
-            "-h" | "--help" => {
-                println!("{}", usage());
-                std::process::exit(0);
-            }
-            _ => {
-                return Err(format!("unknown argument: {arg}\n{}", usage()));
-            }
-        }
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.iter().any(|a| a == "-h" || a == "--help") {
+        println!("{}", usage());
+        std::process::exit(0);
+    }
+    if let Some(arg) = args.first() {
+        return Err(format!("unknown argument: {arg}\n{}", usage()));
     }
     Ok(())
 }

--- a/crates/kelvin-wasm/src/model_host.rs
+++ b/crates/kelvin-wasm/src/model_host.rs
@@ -365,7 +365,7 @@ fn model_input_to_openai_chat_completions_request(input: &ModelInput, model_name
                 if schema.get("type").and_then(Value::as_str) == Some("object")
                     && !schema
                         .as_object()
-                        .map_or(false, |o| o.contains_key("properties"))
+                        .is_some_and(|o| o.contains_key("properties"))
                 {
                     schema["properties"] = json!({});
                 }


### PR DESCRIPTION
Resolves all 10 clippy warnings across 6 files. `cargo clippy --workspace -- -D warnings` now passes clean.

Changes:
- Collapse else-if block in `app.rs`
- Replace manual `div_ceil` with `.div_ceil()` in `app.rs`
- Replace `map_or(false, ...)` with `is_some_and(...)` in `app.rs`, `status.rs`, `model_host.rs`
- Use iterator enumerate instead of indexing loop variable in `chat.rs`
- Remove useless `.into()` conversion in `ws_client.rs`
- Remove needless return statement in `ws_client.rs`
- Replace never-looping while-let with cleaner conditional in `kelvin-memory-controller`