### PR TITLE
security: bump aws-lc-sys and rustls-webpki to fix 3 CVEs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
 dependencies = [
  "cc",
  "cmake",
@@ -3139,7 +3139,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -3187,9 +3187,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
Bumps two transitive dependencies to resolve 3 known security vulnerabilities:

- **RUSTSEC-2026-0044**: `aws-lc-sys` X.509 Name Constraints Bypass via Wildcard/Unicode CN
- **RUSTSEC-2026-0048**: `aws-lc-sys` CRL Distribution Point Scope Check Logic Error
- **RUSTSEC-2026-0049**: `rustls-webpki` CRL matching logic error

Updates:
- `aws-lc-rs` 1.16.1 -> 1.16.2
- `aws-lc-sys` 0.38.0 -> 0.39.0
- `rustls-webpki` 0.103.9 -> 0.103.10

`cargo audit` now reports 0 vulnerabilities (3 allowed warnings for unmaintained transitive deps remain).