### PR TITLE
docs: add CHANGELOG.md and SECURITY.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+All notable changes to KelvinClaw will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- CI workflow running on every push and pull request (`cargo fmt`, `clippy`, `build`, `test`, `audit`)
+- Web search tool plugin (`kelvin-websearch-plugin`)
+- Documentation reorganized into categorized subdirectories (`architecture/`, `gateway/`, `getting-started/`, `memory/`, `plugins/`, `security/`)
+
+### Fixed
+- All 37 broken documentation links in README now point to correct subdirectory paths
+- All clippy warnings resolved across the workspace
+- Formatting normalized across 22 source files
+
+### Security
+- Bumped `aws-lc-sys` to 0.39.0 (fixes RUSTSEC-2026-0044, RUSTSEC-2026-0048)
+- Bumped `rustls-webpki` to 0.103.10 (fixes RUSTSEC-2026-0049)
+
+## [0.1.8] - 2025-03-14
+
+### Added
+- Release executables workflow for multi-platform builds (Linux, macOS, Windows)
+- Debian package generation for `amd64` and `arm64`
+- Plugin author Docker workflow
+- Plugin signing and trust policy operations
+- OpenRouter model plugin
+- Anthropic model plugin
+- Memory controller deployment profiles
+- Memory module SDK and WIT contract
+- Gateway channel plugin ABI (Telegram, Slack, Discord ingress)
+- Operator console on gateway HTTP listener
+- Plugin quality tiers and compatibility contracts
+- NIST AI RMF 1.0 and OWASP Top 10 AI 2025 compliance documentation
+
+### Changed
+- Plugins are now built from source and baked into Docker runtime image
+- CLI plugin executed through secure installed-plugin path
+
+## [0.1.7] - 2025-03-10
+
+- Gateway WebSocket protocol and TUI client
+- Memory RPC contract and gRPC service
+- Plugin index schema and discovery
+
+## [0.1.6] - 2025-03-07
+
+- Trusted executive + untrusted WASM skills split model
+- Sandbox policy presets and capability gates
+- Ed25519 plugin signing
+
+## [0.1.5] - 2025-03-04
+
+- SDK runtime integration path
+- Plugin factory and registry
+- In-memory plugin registry with policy-gated registration
+
+## [0.1.4] - 2025-02-28
+
+- Initial workspace structure
+- Core contracts and shared types
+- Brain agent loop orchestration
+- WASM execution engine
+- Memory backends (Markdown, InMemoryVector, fallback)
+
+[Unreleased]: https://github.com/AgenticHighway/kelvinclaw/compare/v0.1.8...HEAD
+[0.1.8]: https://github.com/AgenticHighway/kelvinclaw/compare/v0.1.7...v0.1.8
+[0.1.7]: https://github.com/AgenticHighway/kelvinclaw/compare/v0.1.6...v0.1.7
+[0.1.6]: https://github.com/AgenticHighway/kelvinclaw/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.com/AgenticHighway/kelvinclaw/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/AgenticHighway/kelvinclaw/releases/tag/v0.1.4

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,74 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.1.x   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in KelvinClaw, please report it
+responsibly. **Do not open a public GitHub issue for security vulnerabilities.**
+
+### How to Report
+
+1. **Email**: Send a description of the vulnerability to the repository maintainers
+   via the contact information on the [AgenticHighway organization profile](https://github.com/AgenticHighway).
+2. **GitHub Security Advisories**: Use the
+   [private vulnerability reporting](https://github.com/AgenticHighway/kelvinclaw/security/advisories/new)
+   feature on this repository.
+
+### What to Include
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof of concept
+- The affected version(s)
+- Any suggested fix or mitigation
+
+### Response Timeline
+
+- **Acknowledgement**: Within 48 hours of receiving the report
+- **Assessment**: Within 7 days, we will provide an initial assessment
+- **Fix**: Critical vulnerabilities will be prioritized for the next patch release
+
+### Scope
+
+The following are in scope for security reports:
+
+- All Rust crates in the `crates/` and `apps/` directories
+- Plugin signing and trust verification (`Ed25519`, `plugin.sig`)
+- WASM sandbox policy enforcement (`SandboxPolicy`, `SandboxPreset`)
+- Gateway authentication and WebSocket protocol
+- Memory controller RPC and access controls
+- Docker images and runtime container security
+- Secret handling and credential management
+
+### Out of Scope
+
+- Third-party plugins not published by AgenticHighway
+- Vulnerabilities in upstream dependencies (report those to the upstream project)
+- Issues requiring physical access to the host machine
+
+## Security Design
+
+KelvinClaw is designed with security as a first-class concern:
+
+- **Plugin sandboxing**: Untrusted WASM plugins run in a sandboxed environment
+  with explicit capability gates
+- **Signed packages**: Plugin manifests are signed with Ed25519 and verified
+  against a trusted publisher policy
+- **Fail-closed defaults**: Missing or invalid configuration causes startup
+  failure rather than permissive fallback
+- **Network mediation**: All network access from plugins is host-mediated with
+  explicit allowlists
+- **Memory isolation**: Memory operations go through the data-plane RPC with
+  security checks
+
+For detailed security documentation, see:
+
+- [SDK OWASP Top 10 AI 2025](docs/security/sdk-owasp-top10-ai-2025.md)
+- [SDK NIST AI RMF 1.0](docs/security/sdk-nist-ai-rmf-1-0.md)
+- [SDK Test Matrix](docs/security/sdk-test-matrix.md)
+- [Core Admission Policy](docs/architecture/core-admission-policy.md)
+- [Trusted Executive WASM](docs/architecture/trusted-executive-wasm.md)


### PR DESCRIPTION
Adds two standard community files:

### CHANGELOG.md
- Follows [Keep a Changelog](https://keepachangelog.com/) format
- Documents all tagged releases from v0.1.4 through v0.1.8
- Includes unreleased changes (CI, formatting, clippy, security bumps, doc link fixes)

### SECURITY.md
- Vulnerability reporting instructions (email + GitHub Security Advisories)
- Response timeline (48h ack, 7d assessment)
- In-scope and out-of-scope definitions
- Links to existing security documentation