### PR TITLE
docs: add CONTRIBUTING.md and CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement via the contact
+information on the [AgenticHighway organization profile](https://github.com/AgenticHighway).
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,97 @@
+# Contributing to KelvinClaw
+
+Thank you for your interest in contributing to KelvinClaw. This document
+explains how to get started.
+
+## Getting Started
+
+1. Fork the repository and clone your fork.
+2. Install the Rust toolchain (stable channel).
+3. Run `cargo build --workspace` to verify everything compiles.
+4. Run `cargo test --workspace` to confirm all tests pass.
+
+For Docker-based development without a local Rust toolchain:
+
+```bash
+scripts/plugin-author-docker.sh -- bash
+```
+
+## Development Workflow
+
+### Before Submitting a PR
+
+Run the full check suite locally:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace -- -D warnings
+cargo test --workspace
+cargo audit
+```
+
+All four commands must pass cleanly. CI enforces the same checks on every PR.
+
+### Commit Messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) style:
+
+- `fix:` for bug fixes
+- `feat:` for new features
+- `docs:` for documentation changes
+- `style:` for formatting-only changes
+- `refactor:` for code restructuring without behavior changes
+- `test:` for adding or updating tests
+- `ci:` for CI/CD changes
+- `security:` for security-related changes
+
+Keep commits scoped and atomic. Only stage files relevant to the change.
+
+### Pull Requests
+
+- Keep PRs focused on a single concern
+- Separate refactors from feature additions from bug fixes
+- Include a clear description of what the PR does and why
+- Reference any related issues
+
+### Code Style
+
+- Follow `rustfmt` defaults (enforced by CI)
+- Follow `clippy` recommendations (enforced by CI)
+- Keep files under 400 lines
+- Keep functions under 50 lines
+- Pass dependencies explicitly rather than using hidden globals
+
+### Testing
+
+- Add tests for new logic, data transformations, and workflow paths
+- Run `scripts/test-sdk.sh` for the SDK certification lane
+- Run `scripts/test-docker.sh` for Docker-based verification
+
+## Architecture
+
+- **Crates are self-contained** and do not directly reference each other,
+  except for the SDK which can reference all crates.
+- **All WASM plugins** must be loaded through the SDK, not directly.
+- **All network access** must go through the SDK with explicit allowlists.
+- **Fail closed** on missing or invalid configuration.
+
+See [OVERVIEW.md](OVERVIEW.md) and [docs/architecture/](docs/architecture/)
+for detailed architecture documentation.
+
+## Plugin Development
+
+To build a new plugin, see:
+
+- [Plugin Author Kit](docs/plugins/plugin-author-kit.md)
+- [Build a Tool Plugin](docs/plugins/build-a-tool-plugin.md)
+- [Build a Model Plugin](docs/plugins/build-a-model-plugin.md)
+
+## Security
+
+Report security vulnerabilities privately. See [SECURITY.md](SECURITY.md)
+for instructions. Do not open public issues for security concerns.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[MIT License](LICENSE).


### PR DESCRIPTION
Adds two standard community files for public open source readiness:

### CONTRIBUTING.md
- Getting started instructions (local Rust and Docker paths)
- Pre-PR checklist (`fmt`, `clippy`, `test`, `audit`)
- Conventional Commits style guide
- Code style rules (file/function size limits, explicit dependencies)
- Architecture constraints and plugin development links

### CODE_OF_CONDUCT.md
- Contributor Covenant v2.1
- Enforcement contacts via AgenticHighway org profile