### PR TITLE
fix: resolve all 9 open issues (#49, #51, #53, #66-71)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2305,6 +2305,7 @@ dependencies = [
  "kelvin-core",
  "reqwest",
  "serde_json",
+ "tokio",
  "url",
  "wasmtime",
  "wat",

--- a/README.md
+++ b/README.md
@@ -589,8 +589,8 @@ kelvin plugin new \
 
 Authoring docs:
 
-- [docs/plugin-author-kit.md](docs/plugins/plugin-author-kit.md)
-- [docs/build-a-model-plugin.md](docs/plugins/build-a-model-plugin.md)
+- [docs/plugins/plugin-author-kit.md](docs/plugins/plugin-author-kit.md)
+- [docs/plugins/build-a-model-plugin.md](docs/plugins/build-a-model-plugin.md)
 
 Trust policy template:
 

--- a/apps/kelvin-gateway/src/channels.rs
+++ b/apps/kelvin-gateway/src/channels.rs
@@ -1629,8 +1629,8 @@ impl TextChannelAdapter {
                 // bot_token is the WhatsApp Cloud API access token.
                 // account_id is the recipient phone number (user_phone).
                 // We need the phone_number_id from env to construct the endpoint.
-                let phone_number_id = std::env::var("KELVIN_WHATSAPP_PHONE_NUMBER_ID")
-                    .unwrap_or_default();
+                let phone_number_id =
+                    std::env::var("KELVIN_WHATSAPP_PHONE_NUMBER_ID").unwrap_or_default();
                 let endpoint = format!("{}/{}/messages", base, phone_number_id);
                 let request = self
                     .client

--- a/apps/kelvin-gateway/src/ingress/whatsapp.rs
+++ b/apps/kelvin-gateway/src/ingress/whatsapp.rs
@@ -105,27 +105,13 @@ pub(super) async fn handle_verify(
 
     if mode != "subscribe" {
         let message = "whatsapp webhook verification: hub.mode is not 'subscribe'";
-        record_webhook_denied(
-            &state.gateway,
-            kind,
-            StatusCode::FORBIDDEN,
-            false,
-            message,
-        )
-        .await;
+        record_webhook_denied(&state.gateway, kind, StatusCode::FORBIDDEN, false, message).await;
         return json_error(StatusCode::FORBIDDEN, "verification_failed", message);
     }
 
     if token != configured_token {
         let message = "whatsapp webhook verification: verify token mismatch";
-        record_webhook_denied(
-            &state.gateway,
-            kind,
-            StatusCode::FORBIDDEN,
-            false,
-            message,
-        )
-        .await;
+        record_webhook_denied(&state.gateway, kind, StatusCode::FORBIDDEN, false, message).await;
         return json_error(StatusCode::FORBIDDEN, "verification_failed", message);
     }
 
@@ -278,9 +264,7 @@ fn verify_signature(app_secret: &str, headers: &HeaderMap, body: &[u8]) -> Resul
         .and_then(|v| v.to_str().ok())
         .map(str::trim)
         .filter(|v| !v.is_empty())
-        .ok_or_else(|| {
-            "missing x-hub-signature-256 header for whatsapp webhook".to_string()
-        })?;
+        .ok_or_else(|| "missing x-hub-signature-256 header for whatsapp webhook".to_string())?;
 
     let Some(encoded_signature) = signature_header.strip_prefix("sha256=") else {
         return Err("whatsapp signature must start with 'sha256='".to_string());

--- a/apps/kelvin-tui/src/app.rs
+++ b/apps/kelvin-tui/src/app.rs
@@ -262,6 +262,8 @@ pub struct App {
     pub autocomplete_visible: bool,
     pub autocomplete_items: Vec<CompletionItem>,
     pub autocomplete_selected: usize,
+    /// Scroll offset so that the selected row is always visible (#49).
+    pub autocomplete_scroll_offset: usize,
     pub session_id: String,
 }
 
@@ -304,6 +306,7 @@ impl App {
             autocomplete_visible: false,
             autocomplete_items: Vec::new(),
             autocomplete_selected: 0,
+            autocomplete_scroll_offset: 0,
             session_id,
         }
     }
@@ -740,6 +743,16 @@ fn is_word_char(c: char) -> bool {
     c.is_alphanumeric() || c == '_'
 }
 
+/// Keep `autocomplete_scroll_offset` in sync so the selected item is visible.
+fn sync_autocomplete_scroll(app: &mut App) {
+    let max_vis = crate::ui::AUTOCOMPLETE_MAX_VISIBLE;
+    if app.autocomplete_selected < app.autocomplete_scroll_offset {
+        app.autocomplete_scroll_offset = app.autocomplete_selected;
+    } else if app.autocomplete_selected >= app.autocomplete_scroll_offset + max_vis {
+        app.autocomplete_scroll_offset = app.autocomplete_selected + 1 - max_vis;
+    }
+}
+
 /// Update the autocomplete popup based on the current input.
 fn update_autocomplete(app: &mut App) {
     // Only trigger if input starts with '/' and cursor is still in the command name
@@ -752,6 +765,7 @@ fn update_autocomplete(app: &mut App) {
             // Clamp selected index.
             if app.autocomplete_selected >= items.len() {
                 app.autocomplete_selected = 0;
+                app.autocomplete_scroll_offset = 0;
             }
             app.autocomplete_items = items;
             return;
@@ -760,6 +774,7 @@ fn update_autocomplete(app: &mut App) {
     app.autocomplete_visible = false;
     app.autocomplete_items.clear();
     app.autocomplete_selected = 0;
+    app.autocomplete_scroll_offset = 0;
 }
 
 /// Format a command result payload into a readable string for the chat.
@@ -1099,6 +1114,7 @@ async fn run_loop(
                             app.autocomplete_visible = false;
                             app.autocomplete_items.clear();
                             app.autocomplete_selected = 0;
+                            app.autocomplete_scroll_offset = 0;
                         } else {
                             app.selection = None;
                         }
@@ -1116,6 +1132,7 @@ async fn run_loop(
                             app.autocomplete_visible = false;
                             app.autocomplete_items.clear();
                             app.autocomplete_selected = 0;
+                            app.autocomplete_scroll_offset = 0;
                         }
                         if !app.input.trim().is_empty() {
                             let prompt = app.input.clone();
@@ -1134,6 +1151,7 @@ async fn run_loop(
                             app.autocomplete_visible = false;
                             app.autocomplete_items.clear();
                             app.autocomplete_selected = 0;
+                            app.autocomplete_scroll_offset = 0;
 
                             // Dispatch slash commands; send everything else as a prompt.
                             if let Some((cmd_name, args)) =
@@ -1346,6 +1364,7 @@ async fn run_loop(
                         if app.autocomplete_visible && !app.autocomplete_items.is_empty() {
                             app.autocomplete_selected =
                                 (app.autocomplete_selected + 1) % app.autocomplete_items.len();
+                            sync_autocomplete_scroll(app);
                         }
                     }
                     KeyCode::BackTab => {
@@ -1354,6 +1373,7 @@ async fn run_loop(
                                 .autocomplete_selected
                                 .checked_sub(1)
                                 .unwrap_or(app.autocomplete_items.len() - 1);
+                            sync_autocomplete_scroll(app);
                         }
                     }
                     KeyCode::Backspace => {
@@ -1450,6 +1470,7 @@ async fn run_loop(
                                 .autocomplete_selected
                                 .checked_sub(1)
                                 .unwrap_or(app.autocomplete_items.len() - 1);
+                            sync_autocomplete_scroll(app);
                         } else if !app.input_history.is_empty() {
                             let next_idx = match app.history_idx {
                                 None => {
@@ -1468,6 +1489,7 @@ async fn run_loop(
                         if app.autocomplete_visible && !app.autocomplete_items.is_empty() {
                             app.autocomplete_selected =
                                 (app.autocomplete_selected + 1) % app.autocomplete_items.len();
+                            sync_autocomplete_scroll(app);
                         } else {
                             match app.history_idx {
                                 None => {}

--- a/apps/kelvin-tui/src/ui/autocomplete.rs
+++ b/apps/kelvin-tui/src/ui/autocomplete.rs
@@ -9,7 +9,7 @@ use ratatui::{
 use crate::app::App;
 
 /// Maximum number of completions shown at once.
-const MAX_VISIBLE: usize = 8;
+pub const MAX_VISIBLE: usize = 8;
 
 /// Render the autocomplete popup floating just above `input_area`.
 /// Does nothing if `app.autocomplete_visible` is false or the area is too small.
@@ -42,13 +42,16 @@ pub fn render(f: &mut Frame, app: &App, input_area: Rect) {
     // Clear the area behind the popup.
     f.render_widget(Clear, popup_area);
 
+    let offset = app.autocomplete_scroll_offset;
     let items: Vec<ListItem> = app
         .autocomplete_items
         .iter()
+        .skip(offset)
         .take(MAX_VISIBLE)
         .enumerate()
         .map(|(idx, item)| {
-            let style = if idx == app.autocomplete_selected {
+            let abs_idx = offset + idx;
+            let style = if abs_idx == app.autocomplete_selected {
                 Style::default()
                     .fg(Color::Black)
                     .bg(Color::Yellow)
@@ -80,6 +83,6 @@ pub fn render(f: &mut Frame, app: &App, input_area: Rect) {
 
     let list = List::new(items).block(block);
     let mut list_state = ListState::default();
-    list_state.select(Some(app.autocomplete_selected));
+    list_state.select(Some(app.autocomplete_selected.saturating_sub(offset)));
     f.render_stateful_widget(list, popup_area, &mut list_state);
 }

--- a/apps/kelvin-tui/src/ui/mod.rs
+++ b/apps/kelvin-tui/src/ui/mod.rs
@@ -6,6 +6,7 @@ use ratatui::{
 use crate::app::App;
 
 mod autocomplete;
+pub use autocomplete::MAX_VISIBLE as AUTOCOMPLETE_MAX_VISIBLE;
 mod chat;
 mod input;
 mod status;

--- a/crates/kelvin-brain/src/installed_plugins.rs
+++ b/crates/kelvin-brain/src/installed_plugins.rs
@@ -1997,10 +1997,18 @@ fn sandbox_from_manifest(manifest: &InstalledPluginPackageManifest) -> KelvinRes
         policy.network_allow_hosts = manifest.capability_scopes.network_allow_hosts.clone();
     }
     if !manifest.capability_scopes.env_allow.is_empty() {
+        // Require EnvAccess capability for env_allow scopes (#67)
+        if !manifest.capabilities.contains(&PluginCapability::EnvAccess) {
+            return Err(KelvinError::InvalidInput(format!(
+                "plugin '{}' declares env_allow scopes but lacks 'env_access' capability",
+                manifest.id
+            )));
+        }
         policy.env_allow = manifest.capability_scopes.env_allow.clone();
     }
     if let Some(budget) = manifest.operational_controls.fuel_budget {
-        policy.fuel_budget = budget;
+        // Clamp fuel_budget to the hard upper bound (#69)
+        policy.fuel_budget = budget.min(kelvin_wasm::MAX_FUEL_BUDGET);
     }
     if manifest.capabilities.contains(&PluginCapability::FsWrite)
         || manifest
@@ -2190,6 +2198,10 @@ fn claw_call_json(call: &ClawCall) -> serde_json::Value {
         ClawCall::HttpCall { url } => json!({
             "kind": "http_call",
             "url": url,
+        }),
+        ClawCall::EnvAccess { key } => json!({
+            "kind": "env_access",
+            "key": key,
         }),
     }
 }

--- a/crates/kelvin-brain/src/wasm_skill_tool.rs
+++ b/crates/kelvin-brain/src/wasm_skill_tool.rs
@@ -367,6 +367,7 @@ fn claw_call_label(call: &ClawCall) -> String {
         ClawCall::FsRead { handle } => format!("fs_read({handle})"),
         ClawCall::NetworkSend { packet } => format!("network_send({packet})"),
         ClawCall::HttpCall { url } => format!("http_call({url})"),
+        ClawCall::EnvAccess { key } => format!("env_access({key})"),
     }
 }
 
@@ -392,6 +393,10 @@ fn claw_call_json(call: &ClawCall) -> Value {
         ClawCall::HttpCall { url } => json!({
             "kind": "http_call",
             "url": url,
+        }),
+        ClawCall::EnvAccess { key } => json!({
+            "kind": "env_access",
+            "key": key,
         }),
     }
 }

--- a/crates/kelvin-core/src/sdk.rs
+++ b/crates/kelvin-core/src/sdk.rs
@@ -32,6 +32,7 @@ pub enum PluginCapability {
     NetworkEgress,
     CommandExecution,
     CommandProvider,
+    EnvAccess,
 }
 
 /// Metadata describing a single slash command provided by the gateway or a plugin.

--- a/crates/kelvin-wasm/Cargo.toml
+++ b/crates/kelvin-wasm/Cargo.toml
@@ -11,6 +11,7 @@ wasmtime.workspace = true
 serde_json.workspace = true
 reqwest.workspace = true
 url.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 wat = "1"

--- a/crates/kelvin-wasm/src/lib.rs
+++ b/crates/kelvin-wasm/src/lib.rs
@@ -36,6 +36,9 @@ pub mod claw_abi {
 
 pub const DEFAULT_MAX_MODULE_BYTES: usize = 512 * 1024;
 pub const DEFAULT_FUEL_BUDGET: u64 = 1_000_000;
+/// Hard upper bound on fuel_budget to prevent manifests from requesting
+/// unbounded execution time (#69).
+pub const MAX_FUEL_BUDGET: u64 = 100_000_000;
 pub const DEFAULT_MAX_REQUEST_BYTES: usize = 256 * 1024;
 pub const DEFAULT_MAX_RESPONSE_BYTES: usize = 256 * 1024;
 
@@ -46,6 +49,7 @@ pub enum ClawCall {
     FsRead { handle: i32 },
     NetworkSend { packet: i32 },
     HttpCall { url: String },
+    EnvAccess { key: String },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -535,10 +539,21 @@ fn link_claw_imports(linker: &mut Linker<HostState>, policy: &SandboxPolicy) -> 
                     };
 
                     // --- enforce allowlist ---
-                    let hostname = url::Url::parse(&url_str)
+                    let hostname = match url::Url::parse(&url_str)
                         .ok()
                         .and_then(|u| u.host_str().map(|h| h.to_string()))
-                        .unwrap_or_default();
+                    {
+                        Some(h) if !h.is_empty() => h,
+                        _ => {
+                            // Reject unparseable or host-less URLs (#71)
+                            return write_resp_to_buf(
+                                &mut caller,
+                                &serde_json::json!({"status": 400, "body": "invalid or missing hostname in URL"}).to_string(),
+                                resp_ptr,
+                                resp_max_len,
+                            );
+                        }
+                    };
                     caller.data_mut().record(ClawCall::HttpCall { url: url_str.clone() });
 
                     // --- build response JSON ---
@@ -574,14 +589,24 @@ fn link_claw_imports(linker: &mut Linker<HostState>, policy: &SandboxPolicy) -> 
                             _ => client.get(&url_str),
                         };
                         // Optional headers object: {"Header-Name": "value", ...}
+                        // Block security-sensitive headers to prevent injection (#70).
+                        const BLOCKED_HEADERS: &[&str] = &[
+                            "host", "authorization", "proxy-authorization",
+                            "cookie", "set-cookie", "transfer-encoding",
+                            "te", "connection", "upgrade",
+                        ];
                         if let Some(hdrs) = req.get("headers").and_then(|v| v.as_object()) {
                             for (k, v) in hdrs {
                                 if let Some(val) = v.as_str() {
-                                    req_builder = req_builder.header(k.as_str(), val);
+                                    if !BLOCKED_HEADERS.contains(&k.to_ascii_lowercase().as_str()) {
+                                        req_builder = req_builder.header(k.as_str(), val);
+                                    }
                                 }
                             }
                         }
-                        match req_builder.send() {
+                        // Wrap blocking HTTP in block_in_place to avoid starving
+                        // the tokio runtime (#66).
+                        match tokio::task::block_in_place(|| req_builder.send()) {
                             Ok(resp) => {
                                 let status = resp.status().as_u16();
                                 let text = resp.text().unwrap_or_default();
@@ -652,6 +677,9 @@ fn link_claw_imports(linker: &mut Linker<HostState>, policy: &SandboxPolicy) -> 
                     if !env_allow.iter().any(|allowed| allowed == key) {
                         return 0;
                     }
+                    caller.data_mut().record(ClawCall::EnvAccess {
+                        key: key.to_string(),
+                    });
                     let value = match std::env::var(key) {
                         Ok(v) => v,
                         Err(_) => return 0,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,11 +108,13 @@ services:
 
   # TUI client — connects to kelvin-gateway over the internal Docker network
   # Usage: docker compose run --rm kelvin-tui
+  # After exiting: docker compose down --remove-orphans
   kelvin-tui:
     build:
       context: .
       dockerfile: docker/Dockerfile.tui
     container_name: kelvin-tui
+    init: true
     stdin_open: true
     tty: true
     environment:

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -241,7 +241,7 @@ kelvin plugin test --manifest ./plugin-acme.echo/plugin.json
 
 For the supported model-plugin contributor path, use:
 
-- `docs/build-a-model-plugin.md`
+- `docs/plugins/build-a-model-plugin.md`
 - `plugins/kelvin-anthropic-plugin`
 - `plugins/kelvin-openrouter-plugin`
 

--- a/docs/plugins/plugin-author-kit.md
+++ b/docs/plugins/plugin-author-kit.md
@@ -50,11 +50,11 @@ scripts/kelvin-plugin.sh verify --package ./plugin-acme.echo/dist/acme.echo-0.1.
 
 For model plugins, use the dedicated guide:
 
-- [docs/build-a-model-plugin.md](build-a-model-plugin.md)
+- [docs/plugins/build-a-model-plugin.md](build-a-model-plugin.md)
 
 For tool plugins, use the dedicated guide:
 
-- [docs/build-a-tool-plugin.md](build-a-tool-plugin.md)
+- [docs/plugins/build-a-tool-plugin.md](build-a-tool-plugin.md)
 
 `kelvin plugin new` creates a working source project for both runtimes with:
 

--- a/templates/plugin-author-kit/README.md
+++ b/templates/plugin-author-kit/README.md
@@ -22,7 +22,7 @@ For working model-plugin source, also see:
 
 - `plugins/kelvin-anthropic-plugin`
 - `plugins/kelvin-openrouter-plugin`
-- `docs/build-a-model-plugin.md`
+- `docs/plugins/build-a-model-plugin.md`
 
 Template manifests:
 


### PR DESCRIPTION
Triaged all 9 open issues against the current codebase — all were still present. This PR fixes them all:

## Security Fixes (WASM sandbox)

- **Fixes #71** — URL parse failure in `http_call` no longer falls through with empty hostname. Unparseable or host-less URLs now return a 400 response immediately.
- **Fixes #70** — WASM plugins can no longer inject arbitrary HTTP headers. Security-sensitive headers (`Host`, `Authorization`, `Cookie`, `Proxy-Authorization`, `Transfer-Encoding`, `Connection`, `Upgrade`, `Te`, `Set-Cookie`) are now blocked.
- **Fixes #69** — `fuel_budget` is now capped at `MAX_FUEL_BUDGET` (100M). Manifest values above this are silently clamped.
- **Fixes #68** — Env variable reads from WASM plugins are now recorded in the `ClawCall` audit trail via a new `ClawCall::EnvAccess { key }` variant.
- **Fixes #67** — `env_allow` capability scopes now require a corresponding `EnvAccess` capability in the plugin manifest. Without it, the plugin is rejected at load time.
- **Fixes #66** — `reqwest::blocking` HTTP calls inside the wasmtime host callback are now wrapped in `tokio::task::block_in_place` to prevent starving the tokio runtime.

## Documentation Fix

- **Fixes #53** — Link labels that suggested paths like `docs/build-a-model-plugin.md` now correctly show `docs/plugins/build-a-model-plugin.md` to match the actual file locations.

## Docker Fix

- **Fixes #51** — Added `init: true` to the `kelvin-tui` docker-compose service for proper signal handling, and documented the `docker compose down --remove-orphans` cleanup step.

## TUI Fix

- **Fixes #49** — Autocomplete popup now scrolls to keep the selected item visible when there are more items than `MAX_VISIBLE` (8). Added `autocomplete_scroll_offset` field and `sync_autocomplete_scroll` helper.

---

All 50 tests passing. `cargo fmt`, `cargo clippy` clean.