### PR TITLE
fix: guard KELVIN_CLI_VERSION before use in release launcher (unbound variable crash)

### DIFF
--- a/scripts/kelvin-release-launcher.sh
+++ b/scripts/kelvin-release-launcher.sh
@@ -238,9 +238,11 @@ bootstrap_official_plugins() {
   # shellcheck disable=SC1090
   source "${PLUGIN_MANIFEST_PATH}"
 
-  install_official_plugin "kelvin.cli" "${KELVIN_CLI_VERSION}" "${KELVIN_CLI_PACKAGE_URL}" "${KELVIN_CLI_SHA256}"
+  if [[ -n "${KELVIN_CLI_VERSION:-}" ]]; then
+    install_official_plugin "kelvin.cli" "${KELVIN_CLI_VERSION}" "${KELVIN_CLI_PACKAGE_URL}" "${KELVIN_CLI_SHA256}"
+  fi
 
-  if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+  if [[ -n "${OPENAI_API_KEY:-}" && -n "${KELVIN_OPENAI_VERSION:-}" ]]; then
     install_official_plugin "kelvin.openai" "${KELVIN_OPENAI_VERSION}" "${KELVIN_OPENAI_PACKAGE_URL}" "${KELVIN_OPENAI_SHA256}"
   fi
 }


### PR DESCRIPTION
## Problem

Users running `./kelvin` from a release bundle get:

```
./kelvin: line 241: KELVIN_CLI_VERSION: unbound variable
```

`bootstrap_official_plugins()` does `source "${PLUGIN_MANIFEST_PATH}"` then unconditionally references `${KELVIN_CLI_VERSION}`. With `set -euo pipefail` active, this crashes because `official-first-party-plugins.env` no longer defines those variables — the distribution model moved to Docker-built plugins, emptying the manifest of its variable definitions.

## Fix

Wrap each `install_official_plugin` call in an `-n` guard. When the manifest doesn't define the variable the function is silently skipped instead of aborting with an unbound-variable error.

```bash
# Before
install_official_plugin "kelvin.cli" "${KELVIN_CLI_VERSION}" ...

# After  
if [[ -n "${KELVIN_CLI_VERSION:-}" ]]; then
  install_official_plugin "kelvin.cli" "${KELVIN_CLI_VERSION}" ...
fi
```

This is fully backwards-compatible: release bundles that _do_ populate the manifest will continue installing plugins as before.