### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-brain"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-core"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "semver",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-gateway"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "axum",
  "ed25519-dalek",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-host"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "kelvin-core",
  "kelvin-sdk",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-memory"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "kelvin-core",
@@ -2180,7 +2180,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-memory-api"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -2198,7 +2198,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-memory-client"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-memory-controller"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "jsonwebtoken",
@@ -2241,14 +2241,14 @@ dependencies = [
 
 [[package]]
 name = "kelvin-memory-module-sdk"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "kelvin-registry"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "axum",
  "kelvin-core",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-sdk"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -2285,7 +2285,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-tui"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "crossterm 0.28.1",
  "futures-util",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-wasm"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "kelvin-core",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.9"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["KelvinClaw Contributors"]


### PR DESCRIPTION
## Release v0.2.0

Version bump 0.1.9 → 0.2.0 (workspace `Cargo.toml` + `Cargo.lock`).

### Pre-release validation (all PASS):
- `cargo fmt --check` ✅
- `cargo clippy -D warnings` ✅
- `cargo build --workspace` ✅
- Unit tests: core(46), wasm(34), brain(20), sdk(19), gateway(16), tui(11) — **146 passed** ✅
- `scripts/test-contracts.sh` ✅
- `scripts/test-sdk.sh` ✅
- `cargo audit` — 0 advisories ✅

### Changes since v0.1.9:
- PR #75: Fix `KELVIN_CLI_VERSION: unbound variable` crash in release launcher