### PR TITLE
Add Homebrew release automation

### DIFF
--- a/.github/workflows/release-executables.yml
+++ b/.github/workflows/release-executables.yml
@@ -214,3 +214,86 @@ jobs:
                       release-assets/*.deb.sha256
                   fail_on_unmatched_files: true
                   generate_release_notes: true
+
+    update-homebrew-tap:
+        name: Update Homebrew Tap
+        if: ${{ github.event_name == 'push' }}
+        needs:
+            - resolve-version
+            - publish
+        runs-on: blacksmith-2vcpu-ubuntu-2404
+        timeout-minutes: 15
+        permissions:
+            contents: read
+        env:
+            HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+            RELEASE_VERSION: ${{ needs.resolve-version.outputs.version }}
+        steps:
+            - name: Skip when tap token is not configured
+              if: env.HOMEBREW_TAP_TOKEN == ''
+              run: echo "HOMEBREW_TAP_TOKEN not configured; skipping Homebrew tap refresh."
+
+            - name: Download release artifacts
+              if: env.HOMEBREW_TAP_TOKEN != ''
+              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+              with:
+                  path: release-assets
+                  merge-multiple: true
+
+            - name: Checkout Homebrew tap
+              if: env.HOMEBREW_TAP_TOKEN != ''
+              uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
+              with:
+                  repository: AgenticHighway/homebrew-tap
+                  ref: main
+                  token: ${{ env.HOMEBREW_TAP_TOKEN }}
+                  path: homebrew-tap
+
+            - name: Update Formula/kelvinclaw.rb
+              if: env.HOMEBREW_TAP_TOKEN != ''
+              working-directory: homebrew-tap
+              run: |
+                  set -euo pipefail
+                  export MACOS_ARM64_SHA="$(sha256sum ../release-assets/kelvinclaw-${RELEASE_VERSION}-macos-arm64.tar.gz | awk '{print $1}')"
+                  export MACOS_X86_64_SHA="$(sha256sum ../release-assets/kelvinclaw-${RELEASE_VERSION}-macos-x86_64.tar.gz | awk '{print $1}')"
+                  export LINUX_ARM64_SHA="$(sha256sum ../release-assets/kelvinclaw-${RELEASE_VERSION}-linux-arm64.tar.gz | awk '{print $1}')"
+                  export LINUX_X86_64_SHA="$(sha256sum ../release-assets/kelvinclaw-${RELEASE_VERSION}-linux-x86_64.tar.gz | awk '{print $1}')"
+
+                  ruby <<'RUBY'
+                  path = "Formula/kelvinclaw.rb"
+                  text = File.read(path)
+
+                  replacements = {
+                    /version "\d+\.\d+\.\d+"/ => %(version "#{ENV.fetch("RELEASE_VERSION")}"),
+                    /(macos-arm64\.tar\.gz"\n\s+sha256 ")([0-9a-f]+)"/ => "\\1#{ENV.fetch("MACOS_ARM64_SHA")}\"",
+                    /(macos-x86_64\.tar\.gz"\n\s+sha256 ")([0-9a-f]+)"/ => "\\1#{ENV.fetch("MACOS_X86_64_SHA")}\"",
+                    /(linux-arm64\.tar\.gz"\n\s+sha256 ")([0-9a-f]+)"/ => "\\1#{ENV.fetch("LINUX_ARM64_SHA")}\"",
+                    /(linux-x86_64\.tar\.gz"\n\s+sha256 ")([0-9a-f]+)"/ => "\\1#{ENV.fetch("LINUX_X86_64_SHA")}\""
+                  }
+
+                  replacements.each do |pattern, replacement|
+                    updated = text.sub(pattern, replacement)
+                    raise "failed to update #{pattern.inspect}" if updated == text
+                    text = updated
+                  end
+
+                  File.write(path, text)
+                  RUBY
+
+                  git --no-pager diff -- Formula/kelvinclaw.rb
+
+            - name: Commit and push formula
+              if: env.HOMEBREW_TAP_TOKEN != ''
+              working-directory: homebrew-tap
+              run: |
+                  set -euo pipefail
+                  if git diff --quiet -- Formula/kelvinclaw.rb; then
+                    echo "Formula already up to date."
+                    exit 0
+                  fi
+
+                  git config user.name "github-actions[bot]"
+                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  git add Formula/kelvinclaw.rb
+                  git commit -m "kelvinclaw ${RELEASE_VERSION}"
+                  git push origin HEAD:main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,15 @@ This file defines default expectations for coding agents working in this reposit
 - Only stage files relevant to the requested change.
 - Use clear commit messages that describe intent.
 
+## Branching and Delivery Philosophy
+
+- `main` must stay releasable and working at all times.
+- Prefer short-lived branches over long-running divergence.
+- Merge small, reviewable changes frequently instead of batching large rewrites.
+- Treat CI as a hard quality gate for anything headed to `main`.
+- If a branch stops getting frequent merges, either shrink its scope or merge it behind a safe default.
+- When in doubt, optimize for fast feedback, green builds, and easy rollback.
+
 Below is an AI-optimized AGENTS.md designed specifically for agentic coding environments (Cursor, Claude Code, OpenAI agents, etc.).
 
 It focuses on things that AI coding systems consistently struggle with:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ Requires Rust toolchain, `jq`, `curl`, `tar`, and `openssl`.
 The quickstart prompts you to pick a model provider (OpenAI, Anthropic, OpenRouter)
 or continue with echo mode if you don't have a key.
 
+### Install via Homebrew
+
+```bash
+brew tap AgenticHighway/tap
+brew install kelvinclaw
+cp "$(brew --prefix)/opt/kelvinclaw/libexec/kelvinclaw/.env.example" .env
+kelvin-gateway start
+kelvin-tui
+```
+
 ### More Options
 
 Choose the onboarding path for your experience level:
@@ -97,6 +107,10 @@ unnotarized in this phase.
 Latest public release:
 
 - [GitHub Releases](https://github.com/AgenticHighway/kelvinclaw/releases/latest)
+
+Tagged releases also refresh the Homebrew tap formula in
+`AgenticHighway/homebrew-tap` when the `HOMEBREW_TAP_TOKEN` repository secret is
+configured.
 
 The intended Unix end-user entrypoint is:
 


### PR DESCRIPTION
## Summary
- add Homebrew tap refresh automation to the release workflow
- document the Homebrew install path and maintainer secret
- encode the main-always-working / short-lived branch philosophy in AGENTS.md

## Testing
- cargo fmt --all -- --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-executables.yml"); puts "YAML OK"'
