### PR TITLE
Add kelvin init onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,8 @@ or continue with echo mode if you don't have a key.
 ```bash
 brew tap AgenticHighway/tap
 brew install kelvinclaw
-cp "$(brew --prefix)/opt/kelvinclaw/libexec/kelvinclaw/.env.example" .env
-kelvin-gateway start
-kelvin-tui
+kelvin init
+kelvin
 ```
 
 ### More Options
@@ -117,13 +116,14 @@ The intended Unix end-user entrypoint is:
 ```bash
 tar -xzf kelvinclaw-<version>-linux-<arch>.tar.gz
 cd kelvinclaw-<version>-linux-<arch>
-cp .env.example .env   # configure provider and API key
-./kelvin-gateway start # start gateway daemon
-./kelvin-tui           # launch the TUI
+./kelvin init
+./kelvin
 ```
 
-On first run, `kelvin-gateway start` fetches the official trust policy and
-bootstraps required plugins from the plugin index into `~/.kelvinclaw`.
+On first run, `kelvin init` writes `~/.kelvinclaw/.env`, generates a gateway
+token, and helps select a provider. `kelvin` then fetches the official trust
+policy and bootstraps required plugins from the plugin index into
+`~/.kelvinclaw`.
 
 Additional published first-party model plugins can be installed with `kpm`:
 

--- a/release/README.md
+++ b/release/README.md
@@ -8,12 +8,11 @@ KelvinClaw is a secure, stable, and modular harness for agentic AI workflows.
 tar -xzf kelvinclaw-<version>-linux-<arch>.tar.gz
 cd kelvinclaw-<version>-linux-<arch>
 
-cp .env.example .env          # configure provider and API key
-./kelvin-gateway start        # start gateway daemon
-./kelvin-tui                  # launch the terminal UI
+./kelvin init
+./kelvin
 ```
 
-On first run, `kelvin-gateway start` fetches the official trust policy and bootstraps required plugins into `~/.kelvinclaw`.
+On first run, `kelvin init` writes `~/.kelvinclaw/.env`, generates a gateway token, and helps you choose a provider. `./kelvin` then bootstraps required plugins into `~/.kelvinclaw`.
 
 ### Prerequisites
 
@@ -33,12 +32,13 @@ All launchers auto-read `.env` files in this order:
 3. `~/.kelvinclaw/.env.local`
 4. `~/.kelvinclaw/.env`
 
-Copy `.env.example` to `.env` and set your model provider and API key:
+The recommended path is to let `kelvin init` create `~/.kelvinclaw/.env` for you:
 
 ```bash
-cp .env.example .env
-$EDITOR .env
+./kelvin init
 ```
+
+You can still copy `.env.example` manually if you want a project-local config.
 
 Key variables:
 

--- a/scripts/kelvin-release-launcher.ps1
+++ b/scripts/kelvin-release-launcher.ps1
@@ -7,6 +7,8 @@ if (Test-Path (Join-Path $PSScriptRoot "bin\\kelvin-host.exe")) {
 }
 
 $PluginManifestPath = Join-Path $RootDir "share\\official-first-party-plugins.env"
+$DefaultPluginIndexUrl = "https://raw.githubusercontent.com/AgenticHighway/kelvinclaw-plugins/main/index.json"
+$DefaultOllamaBaseUrl = "http://localhost:11434"
 $_LaunchEnvPaths = @(
     (Join-Path (Get-Location).Path ".env.local"),
     (Join-Path (Get-Location).Path ".env"),
@@ -16,11 +18,12 @@ $_LaunchEnvPaths = @(
 
 function Show-Usage {
 @"
-Usage: .\kelvin.cmd [kelvin-host args]
+Usage: .\kelvin.cmd [init [options] | kelvin-host args]
 
 Release-bundle launcher for KelvinClaw on Windows.
 
 Behavior:
+  - kelvin init writes ~/.kelvinclaw/.env for first-run setup
   - with no args, installs required official plugins on first run
   - starts interactive mode in a terminal
   - falls back to a default prompt when not attached to a console
@@ -32,6 +35,14 @@ Environment:
   KELVIN_STATE_DIR
   KELVIN_DEFAULT_PROMPT
   OPENAI_API_KEY
+"@
+}
+
+function Show-InitUsage {
+@"
+Usage: .\kelvin.cmd init [--provider <echo|openai|anthropic|openrouter|ollama>] [--force]
+
+Initialize KelvinClaw's user config in ~/.kelvinclaw/.env.
 "@
 }
 
@@ -50,6 +61,106 @@ function Strip-WrappingQuotes([string]$Value) {
         if (($Value.StartsWith('"') -and $Value.EndsWith('"')) -or ($Value.StartsWith("'") -and $Value.EndsWith("'"))) {
             return $Value.Substring(1, $Value.Length - 2)
         }
+    }
+    return $Value
+}
+
+function Get-ConfigTemplatePath {
+    $ReleaseTemplate = Join-Path $RootDir "release\env.example"
+    if (Test-Path $ReleaseTemplate) {
+        return $ReleaseTemplate
+    }
+
+    $RootTemplate = Join-Path $RootDir ".env.example"
+    if (Test-Path $RootTemplate) {
+        return $RootTemplate
+    }
+
+    throw "Missing KelvinClaw config template (.env.example)"
+}
+
+function New-GatewayToken {
+    $Bytes = New-Object byte[] 32
+    [System.Security.Cryptography.RandomNumberGenerator]::Create().GetBytes($Bytes)
+    return ([System.BitConverter]::ToString($Bytes)).Replace("-", "").ToLowerInvariant()
+}
+
+function Set-EnvValueInFile([string]$Path, [string]$Key, [string]$Value) {
+    $Lines = if (Test-Path $Path) { Get-Content $Path } else { @() }
+    $Pattern = "^\s*" + [regex]::Escape($Key) + "\s*="
+    $Replacement = "$Key=$Value"
+    $Replaced = $false
+
+    for ($Index = 0; $Index -lt $Lines.Count; $Index++) {
+        if ($Lines[$Index] -match $Pattern) {
+            $Lines[$Index] = $Replacement
+            $Replaced = $true
+            break
+        }
+    }
+
+    if (-not $Replaced) {
+        $Lines += $Replacement
+    }
+
+    Set-Content -Path $Path -Value $Lines
+}
+
+function Resolve-InitProvider([string]$Provider) {
+    switch ($Provider.ToLowerInvariant()) {
+        "echo" { return "echo" }
+        "kelvin.echo" { return "echo" }
+        "openai" { return "openai" }
+        "kelvin.openai" { return "openai" }
+        "anthropic" { return "anthropic" }
+        "kelvin.anthropic" { return "anthropic" }
+        "openrouter" { return "openrouter" }
+        "kelvin.openrouter" { return "openrouter" }
+        "ollama" { return "ollama" }
+        "kelvin.ollama" { return "ollama" }
+        default {
+            throw "Unsupported provider: $Provider. Expected one of: echo, openai, anthropic, openrouter, ollama"
+        }
+    }
+}
+
+function Select-InitProvider {
+    Write-Host "[kelvin init] Choose a provider:"
+    Write-Host "  1) kelvin.echo (Recommended)"
+    Write-Host "  2) kelvin.openai"
+    Write-Host "  3) kelvin.anthropic"
+    Write-Host "  4) kelvin.openrouter"
+    Write-Host "  5) kelvin.ollama"
+    $Selection = (Read-Host "[kelvin init] Provider [1]").Trim()
+
+    switch ($Selection) {
+        "" { return "echo" }
+        "1" { return "echo" }
+        "2" { return "openai" }
+        "3" { return "anthropic" }
+        "4" { return "openrouter" }
+        "5" { return "ollama" }
+        default { return (Resolve-InitProvider $Selection) }
+    }
+}
+
+function Read-SecretValue([string]$Prompt) {
+    $SecureValue = Read-Host $Prompt -AsSecureString
+    $Ptr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($SecureValue)
+    try {
+        return [Runtime.InteropServices.Marshal]::PtrToStringBSTR($Ptr)
+    }
+    finally {
+        if ($Ptr -ne [IntPtr]::Zero) {
+            [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($Ptr)
+        }
+    }
+}
+
+function Read-ValueWithDefault([string]$Prompt, [string]$Default) {
+    $Value = (Read-Host "$Prompt [$Default]").Trim()
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return $Default
     }
     return $Value
 }
@@ -220,10 +331,106 @@ function Bootstrap-OfficialPlugins {
     }
 }
 
+function Invoke-KelvinInit([string[]]$InitArgs) {
+    $Force = $false
+    $Provider = $null
+
+    for ($Index = 0; $Index -lt $InitArgs.Length; $Index++) {
+        switch ($InitArgs[$Index]) {
+            "--force" {
+                $Force = $true
+            }
+            "--provider" {
+                if ($Index + 1 -ge $InitArgs.Length) {
+                    throw "missing value for --provider"
+                }
+                $Provider = Resolve-InitProvider $InitArgs[$Index + 1]
+                $Index++
+            }
+            "-h" {
+                Show-InitUsage
+                return
+            }
+            "--help" {
+                Show-InitUsage
+                return
+            }
+            default {
+                throw "unknown init argument: $($InitArgs[$Index])"
+            }
+        }
+    }
+
+    $KelvinHome = if ($env:KELVIN_HOME) { $env:KELVIN_HOME } else { Join-Path $HOME ".kelvinclaw" }
+    $ConfigEnvPath = Join-Path $KelvinHome ".env"
+    if (-not $Provider) {
+        $Provider = if ([Environment]::UserInteractive) { Select-InitProvider } else { "echo" }
+    }
+
+    if ((Test-Path $ConfigEnvPath) -and -not $Force) {
+        throw "$ConfigEnvPath already exists. Re-run with 'kelvin init --force' to overwrite it."
+    }
+
+    New-Item -ItemType Directory -Force -Path $KelvinHome | Out-Null
+    Copy-Item (Get-ConfigTemplatePath) $ConfigEnvPath -Force
+
+    Set-EnvValueInFile -Path $ConfigEnvPath -Key "KELVIN_GATEWAY_TOKEN" -Value (New-GatewayToken)
+    $PluginIndexUrl = if ($env:KELVIN_PLUGIN_INDEX_URL) { $env:KELVIN_PLUGIN_INDEX_URL } else { $DefaultPluginIndexUrl }
+    Set-EnvValueInFile -Path $ConfigEnvPath -Key "KELVIN_PLUGIN_INDEX_URL" -Value $PluginIndexUrl
+
+    switch ($Provider) {
+        "echo" {
+            Set-EnvValueInFile -Path $ConfigEnvPath -Key "KELVIN_MODEL_PROVIDER" -Value "kelvin.echo"
+        }
+        "openai" {
+            $OpenAIKey = if ($env:OPENAI_API_KEY) { $env:OPENAI_API_KEY } elseif ([Environment]::UserInteractive) { Read-SecretValue "[kelvin init] OpenAI API key" } else { throw "OPENAI_API_KEY must be set for non-interactive openai init" }
+            if ([string]::IsNullOrWhiteSpace($OpenAIKey)) {
+                throw "OPENAI_API_KEY cannot be empty"
+            }
+            Set-EnvValueInFile -Path $ConfigEnvPath -Key "KELVIN_MODEL_PROVIDER" -Value "kelvin.openai"
+            Set-EnvValueInFile -Path $ConfigEnvPath -Key "OPENAI_API_KEY" -Value $OpenAIKey.Trim()
+        }
+        "anthropic" {
+            $AnthropicKey = if ($env:ANTHROPIC_API_KEY) { $env:ANTHROPIC_API_KEY } elseif ([Environment]::UserInteractive) { Read-SecretValue "[kelvin init] Anthropic API key" } else { throw "ANTHROPIC_API_KEY must be set for non-interactive anthropic init" }
+            if ([string]::IsNullOrWhiteSpace($AnthropicKey)) {
+                throw "ANTHROPIC_API_KEY cannot be empty"
+            }
+            Set-EnvValueInFile -Path $ConfigEnvPath -Key "KELVIN_MODEL_PROVIDER" -Value "kelvin.anthropic"
+            Set-EnvValueInFile -Path $ConfigEnvPath -Key "ANTHROPIC_API_KEY" -Value $AnthropicKey.Trim()
+        }
+        "openrouter" {
+            $OpenRouterKey = if ($env:OPENROUTER_API_KEY) { $env:OPENROUTER_API_KEY } elseif ([Environment]::UserInteractive) { Read-SecretValue "[kelvin init] OpenRouter API key" } else { throw "OPENROUTER_API_KEY must be set for non-interactive openrouter init" }
+            if ([string]::IsNullOrWhiteSpace($OpenRouterKey)) {
+                throw "OPENROUTER_API_KEY cannot be empty"
+            }
+            Set-EnvValueInFile -Path $ConfigEnvPath -Key "KELVIN_MODEL_PROVIDER" -Value "kelvin.openrouter"
+            Set-EnvValueInFile -Path $ConfigEnvPath -Key "OPENROUTER_API_KEY" -Value $OpenRouterKey.Trim()
+        }
+        "ollama" {
+            $OllamaBaseUrl = if ($env:OLLAMA_BASE_URL) { $env:OLLAMA_BASE_URL } elseif ([Environment]::UserInteractive) { Read-ValueWithDefault "[kelvin init] Ollama base URL" $DefaultOllamaBaseUrl } else { $DefaultOllamaBaseUrl }
+            if ([string]::IsNullOrWhiteSpace($OllamaBaseUrl)) {
+                throw "OLLAMA_BASE_URL cannot be empty"
+            }
+            Set-EnvValueInFile -Path $ConfigEnvPath -Key "KELVIN_MODEL_PROVIDER" -Value "kelvin.ollama"
+            Set-EnvValueInFile -Path $ConfigEnvPath -Key "OLLAMA_BASE_URL" -Value $OllamaBaseUrl.Trim()
+        }
+    }
+
+    Write-Host "[kelvin init] Wrote $ConfigEnvPath"
+    Write-Host "[kelvin init] Next step: kelvin"
+}
+
 $CliArgs = $args
-if ($CliArgs.Length -gt 0 -and ($CliArgs[0] -eq "-h" -or $CliArgs[0] -eq "--help")) {
-    Show-Usage
-    exit 0
+if ($CliArgs.Length -gt 0) {
+    if ($CliArgs[0] -eq "-h" -or $CliArgs[0] -eq "--help") {
+        Show-Usage
+        exit 0
+    }
+    if ($CliArgs[0] -eq "init") {
+        $InitArgs = if ($CliArgs.Length -gt 1) { $CliArgs[1..($CliArgs.Length - 1)] } else { @() }
+        Invoke-KelvinInit $InitArgs
+        exit 0
+    }
 }
 
 $_LaunchDotenv = Load-Dotenv

--- a/scripts/kelvin-release-launcher.sh
+++ b/scripts/kelvin-release-launcher.sh
@@ -10,6 +10,7 @@ fi
 KELVIN_HOME_DEFAULT="${HOME}/.kelvinclaw"
 KELVIN_HOME="${KELVIN_HOME:-${KELVIN_HOME_DEFAULT}}"
 KELVIN_HOME="${KELVIN_HOME/#\~/${HOME}}"
+CONFIG_ENV_PATH="${KELVIN_HOME}/.env"
 PLUGIN_HOME="${KELVIN_PLUGIN_HOME:-${KELVIN_HOME}/plugins}"
 PLUGIN_HOME="${PLUGIN_HOME/#\~/${HOME}}"
 TRUST_POLICY_PATH="${KELVIN_TRUST_POLICY_PATH:-${KELVIN_HOME}/trusted_publishers.json}"
@@ -17,6 +18,8 @@ TRUST_POLICY_PATH="${TRUST_POLICY_PATH/#\~/${HOME}}"
 STATE_DIR="${KELVIN_STATE_DIR:-${KELVIN_HOME}/state}"
 STATE_DIR="${STATE_DIR/#\~/${HOME}}"
 DEFAULT_PROMPT="${KELVIN_DEFAULT_PROMPT:-What is KelvinClaw?}"
+DEFAULT_PLUGIN_INDEX_URL="https://raw.githubusercontent.com/AgenticHighway/kelvinclaw-plugins/main/index.json"
+DEFAULT_OLLAMA_BASE_URL="http://localhost:11434"
 PLUGIN_MANIFEST_PATH="${ROOT_DIR}/share/official-first-party-plugins.env"
 ENV_SEARCH_PATHS=(
   "${PWD}/.env.local"
@@ -27,11 +30,12 @@ ENV_SEARCH_PATHS=(
 
 usage() {
   cat <<'USAGE'
-Usage: ./kelvin [kelvin-host args]
+Usage: ./kelvin [init [options] | kelvin-host args]
 
 Release-bundle launcher for KelvinClaw.
 
 Behavior:
+  - `kelvin init` writes ~/.kelvinclaw/.env for first-run setup
   - with no args, installs required official plugins on first run
   - starts interactive mode on a TTY
   - falls back to a default prompt when stdin/stdout are not TTYs
@@ -49,6 +53,19 @@ The launcher also reads OPENAI_API_KEY from:
   - ./.env
   - ~/.kelvinclaw/.env.local
   - ~/.kelvinclaw/.env
+USAGE
+}
+
+show_init_usage() {
+  cat <<'USAGE'
+Usage: ./kelvin init [--provider <echo|openai|anthropic|openrouter|ollama>] [--force]
+
+Initialize KelvinClaw's user config in ~/.kelvinclaw/.env.
+
+Options:
+  --provider <name>  Preselect a provider instead of prompting.
+  --force            Overwrite an existing ~/.kelvinclaw/.env.
+  -h, --help         Show this help.
 USAGE
 }
 
@@ -87,6 +104,247 @@ strip_wrapping_quotes() {
     return
   fi
   printf '%s' "${value}"
+}
+
+read_secret_value() {
+  local prompt="$1"
+  local value=""
+  printf '%s' "${prompt}" >&2
+  IFS= read -r -s value
+  printf '\n' >&2
+  printf '%s' "${value}"
+}
+
+read_value_with_default() {
+  local prompt="$1"
+  local default_value="$2"
+  local value=""
+  printf '%s [%s]: ' "${prompt}" "${default_value}" >&2
+  IFS= read -r value
+  value="$(trim_whitespace "${value}")"
+  if [[ -z "${value}" ]]; then
+    printf '%s' "${default_value}"
+    return 0
+  fi
+  printf '%s' "${value}"
+}
+
+config_template_path() {
+  if [[ -f "${ROOT_DIR}/release/env.example" ]]; then
+    printf '%s\n' "${ROOT_DIR}/release/env.example"
+    return 0
+  fi
+  if [[ -f "${ROOT_DIR}/.env.example" ]]; then
+    printf '%s\n' "${ROOT_DIR}/.env.example"
+    return 0
+  fi
+  echo "Missing KelvinClaw config template (.env.example)" >&2
+  exit 1
+}
+
+generate_gateway_token() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 32
+    return 0
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import secrets; print(secrets.token_hex(32))'
+    return 0
+  fi
+  echo "Missing required command: openssl or python3" >&2
+  exit 1
+}
+
+replace_or_append_env_line() {
+  local file="$1"
+  local key="$2"
+  local value="$3"
+  local temp_file=""
+  temp_file="$(mktemp)"
+  awk -v key="${key}" -v value="${value}" '
+    BEGIN { replaced = 0 }
+    $0 ~ "^[[:space:]]*" key "[[:space:]]*=" {
+      print key "=" value
+      replaced = 1
+      next
+    }
+    { print }
+    END {
+      if (!replaced) {
+        print key "=" value
+      }
+    }
+  ' "${file}" > "${temp_file}"
+  mv "${temp_file}" "${file}"
+}
+
+normalize_init_provider() {
+  case "$1" in
+    echo|kelvin.echo) printf '%s\n' 'echo' ;;
+    openai|kelvin.openai) printf '%s\n' 'openai' ;;
+    anthropic|kelvin.anthropic) printf '%s\n' 'anthropic' ;;
+    openrouter|kelvin.openrouter) printf '%s\n' 'openrouter' ;;
+    ollama|kelvin.ollama) printf '%s\n' 'ollama' ;;
+    *)
+      echo "Unsupported provider: $1" >&2
+      echo "Expected one of: echo, openai, anthropic, openrouter, ollama" >&2
+      exit 1
+      ;;
+  esac
+}
+
+prompt_for_init_provider() {
+  local selection=""
+  cat <<'PROMPT' >&2
+[kelvin init] Choose a provider:
+  1) kelvin.echo (Recommended)
+  2) kelvin.openai
+  3) kelvin.anthropic
+  4) kelvin.openrouter
+  5) kelvin.ollama
+PROMPT
+  printf '[kelvin init] Provider [1]: ' >&2
+  IFS= read -r selection
+  selection="$(trim_whitespace "${selection}")"
+  case "${selection}" in
+    ""|1) printf '%s\n' 'echo' ;;
+    2) printf '%s\n' 'openai' ;;
+    3) printf '%s\n' 'anthropic' ;;
+    4) printf '%s\n' 'openrouter' ;;
+    5) printf '%s\n' 'ollama' ;;
+    *)
+      normalize_init_provider "${selection}"
+      ;;
+  esac
+}
+
+run_init() {
+  local force="0"
+  local provider=""
+  local provider_id=""
+  local config_template=""
+  local gateway_token=""
+  local plugin_index_url="${KELVIN_PLUGIN_INDEX_URL:-${DEFAULT_PLUGIN_INDEX_URL}}"
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --force)
+        force="1"
+        shift
+        ;;
+      --provider)
+        provider="$(normalize_init_provider "${2:?missing value for --provider}")"
+        shift 2
+        ;;
+      -h|--help)
+        show_init_usage
+        exit 0
+        ;;
+      *)
+        echo "error: unknown init argument: $1" >&2
+        show_init_usage >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if [[ -z "${provider}" ]]; then
+    if [[ -t 0 && -t 1 ]]; then
+      provider="$(prompt_for_init_provider)"
+    else
+      provider="echo"
+    fi
+  fi
+
+  mkdir -p "${KELVIN_HOME}"
+  if [[ -f "${CONFIG_ENV_PATH}" && "${force}" != "1" ]]; then
+    echo "error: ${CONFIG_ENV_PATH} already exists" >&2
+    echo "Run 'kelvin init --force' to overwrite it." >&2
+    exit 1
+  fi
+
+  config_template="$(config_template_path)"
+  cp "${config_template}" "${CONFIG_ENV_PATH}"
+
+  gateway_token="$(generate_gateway_token)"
+  replace_or_append_env_line "${CONFIG_ENV_PATH}" "KELVIN_GATEWAY_TOKEN" "${gateway_token}"
+  replace_or_append_env_line "${CONFIG_ENV_PATH}" "KELVIN_PLUGIN_INDEX_URL" "${plugin_index_url}"
+
+  case "${provider}" in
+    echo)
+      provider_id="kelvin.echo"
+      ;;
+    openai)
+      local openai_api_key="${OPENAI_API_KEY:-}"
+      if [[ -z "${openai_api_key}" ]]; then
+        if [[ ! -t 0 || ! -t 1 ]]; then
+          echo "error: OPENAI_API_KEY must be set for non-interactive openai init" >&2
+          exit 1
+        fi
+        openai_api_key="$(read_secret_value "[kelvin init] OpenAI API key: ")"
+      fi
+      openai_api_key="$(trim_whitespace "${openai_api_key}")"
+      if [[ -z "${openai_api_key}" ]]; then
+        echo "error: OPENAI_API_KEY cannot be empty" >&2
+        exit 1
+      fi
+      replace_or_append_env_line "${CONFIG_ENV_PATH}" "OPENAI_API_KEY" "${openai_api_key}"
+      provider_id="kelvin.openai"
+      ;;
+    anthropic)
+      local anthropic_api_key="${ANTHROPIC_API_KEY:-}"
+      if [[ -z "${anthropic_api_key}" ]]; then
+        if [[ ! -t 0 || ! -t 1 ]]; then
+          echo "error: ANTHROPIC_API_KEY must be set for non-interactive anthropic init" >&2
+          exit 1
+        fi
+        anthropic_api_key="$(read_secret_value "[kelvin init] Anthropic API key: ")"
+      fi
+      anthropic_api_key="$(trim_whitespace "${anthropic_api_key}")"
+      if [[ -z "${anthropic_api_key}" ]]; then
+        echo "error: ANTHROPIC_API_KEY cannot be empty" >&2
+        exit 1
+      fi
+      replace_or_append_env_line "${CONFIG_ENV_PATH}" "ANTHROPIC_API_KEY" "${anthropic_api_key}"
+      provider_id="kelvin.anthropic"
+      ;;
+    openrouter)
+      local openrouter_api_key="${OPENROUTER_API_KEY:-}"
+      if [[ -z "${openrouter_api_key}" ]]; then
+        if [[ ! -t 0 || ! -t 1 ]]; then
+          echo "error: OPENROUTER_API_KEY must be set for non-interactive openrouter init" >&2
+          exit 1
+        fi
+        openrouter_api_key="$(read_secret_value "[kelvin init] OpenRouter API key: ")"
+      fi
+      openrouter_api_key="$(trim_whitespace "${openrouter_api_key}")"
+      if [[ -z "${openrouter_api_key}" ]]; then
+        echo "error: OPENROUTER_API_KEY cannot be empty" >&2
+        exit 1
+      fi
+      replace_or_append_env_line "${CONFIG_ENV_PATH}" "OPENROUTER_API_KEY" "${openrouter_api_key}"
+      provider_id="kelvin.openrouter"
+      ;;
+    ollama)
+      local ollama_base_url="${OLLAMA_BASE_URL:-${DEFAULT_OLLAMA_BASE_URL}}"
+      if [[ -t 0 && -t 1 ]]; then
+        ollama_base_url="$(read_value_with_default "[kelvin init] Ollama base URL" "${ollama_base_url}")"
+      fi
+      ollama_base_url="$(trim_whitespace "${ollama_base_url}")"
+      if [[ -z "${ollama_base_url}" ]]; then
+        echo "error: OLLAMA_BASE_URL cannot be empty" >&2
+        exit 1
+      fi
+      replace_or_append_env_line "${CONFIG_ENV_PATH}" "OLLAMA_BASE_URL" "${ollama_base_url}"
+      provider_id="kelvin.ollama"
+      ;;
+  esac
+
+  replace_or_append_env_line "${CONFIG_ENV_PATH}" "KELVIN_MODEL_PROVIDER" "${provider_id}"
+
+  echo "[kelvin init] Wrote ${CONFIG_ENV_PATH}"
+  echo "[kelvin init] Provider: ${provider_id}"
+  echo "[kelvin init] Next step: kelvin"
 }
 
 load_env_var_from_file() {
@@ -257,6 +515,11 @@ bootstrap_official_plugins() {
 
 if [[ $# -gt 0 ]]; then
   case "$1" in
+    init)
+      shift
+      run_init "$@"
+      exit 0
+      ;;
     -h|--help)
       usage
       exit 0


### PR DESCRIPTION
## Summary
- add a kelvin init first-run flow to the Unix and Windows release launchers
- generate ~/.kelvinclaw/.env with a secure gateway token and provider-specific setup
- update Homebrew and release docs to use kelvin init as the quick start

Closes #101.

## Testing
- bash -n scripts/kelvin-release-launcher.sh
- HOME=$(mktemp -d) scripts/kelvin-release-launcher.sh init --provider echo
- OPENAI_API_KEY=test-openai-key HOME=$(mktemp -d) scripts/kelvin-release-launcher.sh init --provider openai
- HOME=$(mktemp -d) scripts/kelvin-release-launcher.sh init --provider echo && scripts/kelvin-release-launcher.sh init --provider echo (expects existing-config failure)
- PowerShell syntax validation skipped locally because no pwsh/powershell binary is installed in this environment
