### PR TITLE
Prefer canonical user config

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ kelvin init
 kelvin
 ```
 
+Homebrew and release installs now treat `~/.kelvinclaw/.env` as the canonical config path.
+
 ### More Options
 
 Choose the onboarding path for your experience level:

--- a/release/README.md
+++ b/release/README.md
@@ -27,10 +27,12 @@ On first run, `kelvin init` writes `~/.kelvinclaw/.env`, generates a gateway tok
 
 All launchers auto-read `.env` files in this order:
 
-1. `./.env.local`
-2. `./.env`
-3. `~/.kelvinclaw/.env.local`
-4. `~/.kelvinclaw/.env`
+1. `~/.kelvinclaw/.env.local`
+2. `~/.kelvinclaw/.env`
+3. `./.env.local`
+4. `./.env`
+
+`~/.kelvinclaw/.env` is the canonical config path for release and Homebrew installs.
 
 The recommended path is to let `kelvin init` create `~/.kelvinclaw/.env` for you:
 

--- a/scripts/kelvin-gateway.ps1
+++ b/scripts/kelvin-gateway.ps1
@@ -5,13 +5,14 @@ if (Test-Path (Join-Path $PSScriptRoot "bin\kelvin-gateway.exe")) {
 } else {
     $RootDir = Split-Path -Parent $PSScriptRoot
 }
+$DefaultKelvinHome = if ($env:KELVIN_HOME) { $env:KELVIN_HOME } else { Join-Path $HOME ".kelvinclaw" }
 
 # ── dotenv loader ─────────────────────────────────────────────────────────────
 $_KgwEnvPaths = @(
+    (Join-Path $DefaultKelvinHome ".env.local"),
+    (Join-Path $DefaultKelvinHome ".env"),
     (Join-Path (Get-Location).Path ".env.local"),
-    (Join-Path (Get-Location).Path ".env"),
-    (Join-Path $HOME ".kelvinclaw\.env.local"),
-    (Join-Path $HOME ".kelvinclaw\.env")
+    (Join-Path (Get-Location).Path ".env")
 )
 function _KgwLoadDotenv {
     $Dotenv = @{}
@@ -186,6 +187,12 @@ Environment:
   KELVIN_STATE_DIR           Override gateway state dir (default: $KELVIN_HOME\state)
   KELVIN_PLUGIN_HOME         Override plugin install root
   KELVIN_TRUST_POLICY_PATH   Override trust policy path
+
+Config precedence:
+  1. ~\.kelvinclaw\.env.local
+  2. ~\.kelvinclaw\.env
+  3. .\.env.local
+  4. .\.env
 "@
 }
 

--- a/scripts/kelvin-gateway.sh
+++ b/scripts/kelvin-gateway.sh
@@ -19,6 +19,8 @@ if [[ -x "${SCRIPT_DIR}/bin/kelvin-gateway" ]]; then
 else
   ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 fi
+DEFAULT_KELVIN_HOME="${KELVIN_HOME:-${HOME}/.kelvinclaw}"
+DEFAULT_KELVIN_HOME="${DEFAULT_KELVIN_HOME/#\~/${HOME}}"
 
 # ── dotenv loader ─────────────────────────────────────────────────────────────
 _kgw_trim()   { local v="$1"; v="${v#"${v%%[![:space:]]*}"}"; v="${v%"${v##*[![:space:]]}"}"; printf '%s' "${v}"; }
@@ -30,7 +32,7 @@ _kgw_unquote() {
 }
 load_dotenv() {
   local f line stripped key value
-  for f in "${PWD}/.env.local" "${PWD}/.env" "${HOME}/.kelvinclaw/.env.local" "${HOME}/.kelvinclaw/.env"; do
+  for f in "${DEFAULT_KELVIN_HOME}/.env.local" "${DEFAULT_KELVIN_HOME}/.env" "${PWD}/.env.local" "${PWD}/.env"; do
     [[ -f "${f}" ]] || continue
     while IFS= read -r line || [[ -n "${line}" ]]; do
       stripped="$(_kgw_trim "${line%%#*}")"
@@ -43,12 +45,13 @@ load_dotenv() {
       fi
     done < "${f}"
   done
+  return 0
 }
 load_dotenv
 # ──────────────────────────────────────────────────────────────────────────────
 
 KELVIN_MODEL_PROVIDER="${KELVIN_MODEL_PROVIDER:-kelvin.echo}"
-KELVIN_HOME="${KELVIN_HOME:-${HOME}/.kelvinclaw}"
+KELVIN_HOME="${KELVIN_HOME:-${DEFAULT_KELVIN_HOME}}"
 KELVIN_HOME="${KELVIN_HOME/#\~/${HOME}}"
 PLUGIN_HOME="${KELVIN_PLUGIN_HOME:-${KELVIN_HOME}/plugins}"
 PLUGIN_HOME="${PLUGIN_HOME/#\~/${HOME}}"
@@ -173,6 +176,12 @@ Examples:
   ./kelvin-gateway stop
   ./kelvin-gateway restart
   ./kelvin-gateway approve-pairing <code>
+
+Config precedence:
+  1. ~/.kelvinclaw/.env.local
+  2. ~/.kelvinclaw/.env
+  3. ./.env.local
+  4. ./.env
 USAGE
 }
 

--- a/scripts/kelvin-medkit.sh
+++ b/scripts/kelvin-medkit.sh
@@ -190,10 +190,10 @@ section "Configuration"
 
 ENV_FILES_FOUND=0
 for env_path in \
-  "${PWD}/.env.local" \
-  "${PWD}/.env" \
   "${KELVIN_HOME}/.env.local" \
-  "${KELVIN_HOME}/.env"; do
+  "${KELVIN_HOME}/.env" \
+  "${PWD}/.env.local" \
+  "${PWD}/.env"; do
   if [[ -f "${env_path}" ]]; then
     check_pass ".env found: ${env_path}"
     ENV_FILES_FOUND=$((ENV_FILES_FOUND + 1))

--- a/scripts/kelvin-release-launcher.ps1
+++ b/scripts/kelvin-release-launcher.ps1
@@ -9,11 +9,12 @@ if (Test-Path (Join-Path $PSScriptRoot "bin\\kelvin-host.exe")) {
 $PluginManifestPath = Join-Path $RootDir "share\\official-first-party-plugins.env"
 $DefaultPluginIndexUrl = "https://raw.githubusercontent.com/AgenticHighway/kelvinclaw-plugins/main/index.json"
 $DefaultOllamaBaseUrl = "http://localhost:11434"
+$DefaultKelvinHome = if ($env:KELVIN_HOME) { $env:KELVIN_HOME } else { Join-Path $HOME ".kelvinclaw" }
 $_LaunchEnvPaths = @(
+    (Join-Path $DefaultKelvinHome ".env.local"),
+    (Join-Path $DefaultKelvinHome ".env"),
     (Join-Path (Get-Location).Path ".env.local"),
-    (Join-Path (Get-Location).Path ".env"),
-    (Join-Path $HOME ".kelvinclaw\.env.local"),
-    (Join-Path $HOME ".kelvinclaw\.env")
+    (Join-Path (Get-Location).Path ".env")
 )
 
 function Show-Usage {

--- a/scripts/kelvin-release-launcher.sh
+++ b/scripts/kelvin-release-launcher.sh
@@ -22,10 +22,10 @@ DEFAULT_PLUGIN_INDEX_URL="https://raw.githubusercontent.com/AgenticHighway/kelvi
 DEFAULT_OLLAMA_BASE_URL="http://localhost:11434"
 PLUGIN_MANIFEST_PATH="${ROOT_DIR}/share/official-first-party-plugins.env"
 ENV_SEARCH_PATHS=(
-  "${PWD}/.env.local"
-  "${PWD}/.env"
   "${KELVIN_HOME}/.env.local"
   "${KELVIN_HOME}/.env"
+  "${PWD}/.env.local"
+  "${PWD}/.env"
 )
 
 usage() {
@@ -49,10 +49,10 @@ Environment:
   OPENAI_API_KEY             If set, installs and selects kelvin.openai on first run
 
 The launcher also reads OPENAI_API_KEY from:
-  - ./.env.local
-  - ./.env
   - ~/.kelvinclaw/.env.local
   - ~/.kelvinclaw/.env
+  - ./.env.local
+  - ./.env
 USAGE
 }
 
@@ -386,6 +386,7 @@ load_dotenv() {
       fi
     done < "${env_file}"
   done
+  return 0
 }
 
 prompt_for_openai_api_key() {

--- a/scripts/kelvin-tui.ps1
+++ b/scripts/kelvin-tui.ps1
@@ -5,13 +5,14 @@ if (Test-Path (Join-Path $PSScriptRoot "bin\kelvin-tui.exe")) {
 } else {
     $RootDir = Split-Path -Parent $PSScriptRoot
 }
+$DefaultKelvinHome = if ($env:KELVIN_HOME) { $env:KELVIN_HOME } else { Join-Path $HOME ".kelvinclaw" }
 
 # ── dotenv loader ─────────────────────────────────────────────────────────────
 $_TuiEnvPaths = @(
+    (Join-Path $DefaultKelvinHome ".env.local"),
+    (Join-Path $DefaultKelvinHome ".env"),
     (Join-Path (Get-Location).Path ".env.local"),
-    (Join-Path (Get-Location).Path ".env"),
-    (Join-Path $HOME ".kelvinclaw\.env.local"),
-    (Join-Path $HOME ".kelvinclaw\.env")
+    (Join-Path (Get-Location).Path ".env")
 )
 function _TuiLoadDotenv {
     foreach ($F in $_TuiEnvPaths) {
@@ -43,8 +44,8 @@ Environment:
   KELVIN_GATEWAY_TOKEN   Auth token for the gateway (required)
 
 The launcher reads all variables from:
-  - .\.env.local / .\.env
   - ~\.kelvinclaw\.env.local / ~\.kelvinclaw\.env
+  - .\.env.local / .\.env
 
 Pass --help to see kelvin-tui's full option list.
 "@

--- a/scripts/kelvin-tui.sh
+++ b/scripts/kelvin-tui.sh
@@ -15,6 +15,8 @@ if [[ -x "${SCRIPT_DIR}/bin/kelvin-tui" ]]; then
 else
   ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 fi
+DEFAULT_KELVIN_HOME="${KELVIN_HOME:-${HOME}/.kelvinclaw}"
+DEFAULT_KELVIN_HOME="${DEFAULT_KELVIN_HOME/#\~/${HOME}}"
 
 # ── dotenv loader ─────────────────────────────────────────────────────────────
 _ktui_trim()   { local v="$1"; v="${v#"${v%%[![:space:]]*}"}"; v="${v%"${v##*[![:space:]]}"}"; printf '%s' "${v}"; }
@@ -26,7 +28,7 @@ _ktui_unquote() {
 }
 load_dotenv() {
   local f line stripped key value
-  for f in "${PWD}/.env.local" "${PWD}/.env" "${HOME}/.kelvinclaw/.env.local" "${HOME}/.kelvinclaw/.env"; do
+  for f in "${DEFAULT_KELVIN_HOME}/.env.local" "${DEFAULT_KELVIN_HOME}/.env" "${PWD}/.env.local" "${PWD}/.env"; do
     [[ -f "${f}" ]] || continue
     while IFS= read -r line || [[ -n "${line}" ]]; do
       stripped="$(_ktui_trim "${line%%#*}")"
@@ -39,6 +41,7 @@ load_dotenv() {
       fi
     done < "${f}"
   done
+  return 0
 }
 load_dotenv
 # ──────────────────────────────────────────────────────────────────────────────
@@ -54,8 +57,8 @@ Environment:
   KELVIN_HOME            State root (default: ~/.kelvinclaw)
 
 The launcher reads KELVIN_GATEWAY_TOKEN from:
-  - ./.env.local / ./.env
   - ~/.kelvinclaw/.env.local / ~/.kelvinclaw/.env
+  - ./.env.local / ./.env
 
 Pass --help to kelvin-tui for its full option list.
 USAGE

--- a/scripts/kpm.ps1
+++ b/scripts/kpm.ps1
@@ -5,13 +5,14 @@ if (Test-Path (Join-Path $PSScriptRoot "bin\kelvin-gateway.exe")) {
 } else {
     $RootDir = Split-Path -Parent $PSScriptRoot
 }
+$DefaultKelvinHome = if ($env:KELVIN_HOME) { $env:KELVIN_HOME } else { Join-Path $HOME ".kelvinclaw" }
 
 # ── dotenv loader ─────────────────────────────────────────────────────────────
 $_KpmEnvPaths = @(
+    (Join-Path $DefaultKelvinHome ".env.local"),
+    (Join-Path $DefaultKelvinHome ".env"),
     (Join-Path (Get-Location).Path ".env.local"),
-    (Join-Path (Get-Location).Path ".env"),
-    (Join-Path $HOME ".kelvinclaw\.env.local"),
-    (Join-Path $HOME ".kelvinclaw\.env")
+    (Join-Path (Get-Location).Path ".env")
 )
 function _KpmLoadDotenv {
     $Dotenv = @{}
@@ -73,6 +74,12 @@ Environment:
   KELVIN_HOME                State root (default: ~\.kelvinclaw)
   KELVIN_PLUGIN_HOME         Override plugin install root
   KELVIN_TRUST_POLICY_PATH   Override trust policy path
+
+Config precedence:
+  1. ~\.kelvinclaw\.env.local
+  2. ~\.kelvinclaw\.env
+  3. .\.env.local
+  4. .\.env
 "@
 }
 

--- a/scripts/kpm.sh
+++ b/scripts/kpm.sh
@@ -17,6 +17,8 @@ if [[ -x "${SCRIPT_DIR}/bin/kelvin-gateway" ]]; then
 else
   ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 fi
+DEFAULT_KELVIN_HOME="${KELVIN_HOME:-${HOME}/.kelvinclaw}"
+DEFAULT_KELVIN_HOME="${DEFAULT_KELVIN_HOME/#\~/${HOME}}"
 
 # ── dotenv loader ─────────────────────────────────────────────────────────────
 _kpm_trim()   { local v="$1"; v="${v#"${v%%[![:space:]]*}"}"; v="${v%"${v##*[![:space:]]}"}"; printf '%s' "${v}"; }
@@ -28,7 +30,7 @@ _kpm_unquote() {
 }
 load_dotenv() {
   local f line stripped key value
-  for f in "${PWD}/.env.local" "${PWD}/.env" "${HOME}/.kelvinclaw/.env.local" "${HOME}/.kelvinclaw/.env"; do
+  for f in "${DEFAULT_KELVIN_HOME}/.env.local" "${DEFAULT_KELVIN_HOME}/.env" "${PWD}/.env.local" "${PWD}/.env"; do
     [[ -f "${f}" ]] || continue
     while IFS= read -r line || [[ -n "${line}" ]]; do
       stripped="$(_kpm_trim "${line%%#*}")"
@@ -41,11 +43,12 @@ load_dotenv() {
       fi
     done < "${f}"
   done
+  return 0
 }
 load_dotenv
 # ──────────────────────────────────────────────────────────────────────────────
 
-KELVIN_HOME="${KELVIN_HOME:-${HOME}/.kelvinclaw}"
+KELVIN_HOME="${KELVIN_HOME:-${DEFAULT_KELVIN_HOME}}"
 KELVIN_HOME="${KELVIN_HOME/#\~/${HOME}}"
 PLUGIN_HOME="${KELVIN_PLUGIN_HOME:-${KELVIN_HOME}/plugins}"
 PLUGIN_HOME="${PLUGIN_HOME/#\~/${HOME}}"
@@ -117,6 +120,12 @@ Environment:
   KELVIN_HOME                State root (default: ~/.kelvinclaw)
   KELVIN_PLUGIN_HOME         Override plugin install root
   KELVIN_TRUST_POLICY_PATH   Override trust policy path
+
+Config precedence:
+  1. ~/.kelvinclaw/.env.local
+  2. ~/.kelvinclaw/.env
+  3. ./.env.local
+  4. ./.env
 USAGE
 }
 


### PR DESCRIPTION
## Summary
- make ~/.kelvinclaw/.env the first config source for the release launchers
- keep project-local .env files as lower-priority fallback
- document the new precedence and fix bash dotenv helpers so config files do not trip set -e

Refs #102.

## Testing
- bash -n scripts/kelvin-release-launcher.sh scripts/kelvin-gateway.sh scripts/kpm.sh scripts/kelvin-tui.sh scripts/kelvin-medkit.sh
- bash scripts/kpm.sh status from a temp cwd with conflicting home and local .env files (verifies home config wins)
- PowerShell syntax validation skipped locally because no pwsh/powershell binary is installed in this environment
