### PR TITLE
Guard release lockfile and bump version to 0.2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,14 @@ jobs:
             - name: Check formatting
               run: cargo fmt --all -- --check
 
+            - name: Check lockfile
+              run: cargo metadata --format-version 1 --locked > /dev/null
+
             - name: Clippy
-              run: cargo clippy --workspace -- -D warnings
+              run: cargo clippy --locked --workspace -- -D warnings
 
             - name: Test
-              run: cargo test --workspace
+              run: cargo test --locked --workspace
 
     # cargo audit reads Cargo.lock only — no compilation needed.
     audit:

--- a/.github/workflows/release-executables.yml
+++ b/.github/workflows/release-executables.yml
@@ -53,9 +53,40 @@ jobs:
                   fi
                   echo "version=${normalized_version}" >> "${GITHUB_OUTPUT}"
 
+    verify-release-state:
+        name: Verify Release State
+        needs: [resolve-version]
+        runs-on: blacksmith-2vcpu-ubuntu-2404
+        timeout-minutes: 10
+        env:
+            RELEASE_VERSION: ${{ needs.resolve-version.outputs.version }}
+        steps:
+            - name: Checkout
+              uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b
+              with:
+                  persist-credentials: false
+
+            - name: Setup Rust
+              uses: dtolnay/rust-toolchain@efa25f7f19611383d5b0ccf2d1c8914531636bf9
+              with:
+                  toolchain: stable
+
+            - name: Verify tag matches workspace version
+              if: ${{ github.event_name == 'push' }}
+              run: |
+                  set -euo pipefail
+                  workspace_version="$(awk -F'"' '/^version = "/ {print $2; exit}' Cargo.toml)"
+                  if [[ "${workspace_version}" != "${RELEASE_VERSION}" ]]; then
+                    echo "Tag version (${RELEASE_VERSION}) does not match Cargo.toml (${workspace_version})." >&2
+                    exit 1
+                  fi
+
+            - name: Verify Cargo.lock is up to date
+              run: cargo metadata --format-version 1 --locked > /dev/null
+
     build-linux:
         name: Build Linux (${{ matrix.target }})
-        needs: [resolve-version]
+        needs: [resolve-version, verify-release-state]
         runs-on: ${{ matrix.runner }}
         timeout-minutes: 60
         env:
@@ -101,7 +132,7 @@ jobs:
 
     build-macos:
         name: Build macOS (${{ matrix.target }})
-        needs: [resolve-version]
+        needs: [resolve-version, verify-release-state]
         runs-on: ${{ matrix.runner }}
         timeout-minutes: 60
         env:
@@ -143,7 +174,7 @@ jobs:
 
     build-windows:
         name: Build Windows (${{ matrix.target }})
-        needs: [resolve-version]
+        needs: [resolve-version, verify-release-state]
         runs-on: ${{ matrix.runner }}
         timeout-minutes: 60
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,7 +2201,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-brain"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-core"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "semver",
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-gateway"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "axum",
  "ed25519-dalek",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-host"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "kelvin-core",
  "kelvin-sdk",
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-memory"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "kelvin-core",
@@ -2276,7 +2276,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-memory-api"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "base64",
  "jsonwebtoken",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-memory-client"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2317,7 +2317,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-memory-controller"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "jsonwebtoken",
@@ -2337,14 +2337,14 @@ dependencies = [
 
 [[package]]
 name = "kelvin-memory-module-sdk"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "kelvin-registry"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "axum",
  "kelvin-core",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-sdk"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "async-trait",
  "base64",
@@ -2381,7 +2381,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-tui"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "crossterm 0.28.1",
  "futures-util",
@@ -2396,7 +2396,7 @@ dependencies = [
 
 [[package]]
 name = "kelvin-wasm"
-version = "0.2.3"
+version = "0.2.5"
 dependencies = [
  "kelvin-core",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "MIT"
 authors = ["KelvinClaw Contributors"]


### PR DESCRIPTION
- bump workspace version to 0.2.5 and commit Cargo.lock
- make CI run with --locked so version bumps fail before merge
- add release preflight checks for tag/version alignment and lockfile freshness