### PR TITLE
Bootstrap release provider plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ cd kelvinclaw-<version>-linux-<arch>
 ```
 
 On first run, `kelvin init` writes `~/.kelvinclaw/.env`, generates a gateway
-token, and helps select a provider. `kelvin` then fetches the official trust
-policy and bootstraps required plugins from the plugin index into
-`~/.kelvinclaw`.
+token, and helps select a provider. `kelvin` then ensures a trust policy exists
+and bootstraps the `kelvin.cli` toolpack plus the configured model provider
+from the plugin index into `~/.kelvinclaw` when needed.
 
 Additional published first-party model plugins can be installed with `kpm`:
 

--- a/release/README.md
+++ b/release/README.md
@@ -12,7 +12,7 @@ cd kelvinclaw-<version>-linux-<arch>
 ./kelvin
 ```
 
-On first run, `kelvin init` writes `~/.kelvinclaw/.env`, generates a gateway token, and helps you choose a provider. `./kelvin` then bootstraps required plugins into `~/.kelvinclaw`.
+On first run, `kelvin init` writes `~/.kelvinclaw/.env`, generates a gateway token, and helps you choose a provider. `./kelvin` then ensures a trust policy exists and bootstraps the `kelvin.cli` toolpack plus the configured model provider into `~/.kelvinclaw` when needed.
 
 ### Prerequisites
 

--- a/scripts/kelvin-release-launcher.ps1
+++ b/scripts/kelvin-release-launcher.ps1
@@ -227,6 +227,16 @@ function Prompt-ForOpenAIKey([string[]]$CliArgs) {
     }
 }
 
+function Resolve-LaunchModelProvider {
+    if ($env:KELVIN_MODEL_PROVIDER) {
+        return $env:KELVIN_MODEL_PROVIDER
+    }
+    if ($env:OPENAI_API_KEY) {
+        return "kelvin.openai"
+    }
+    return ""
+}
+
 function Plugin-CurrentVersion([string]$PluginId) {
     $CurrentDir = Join-Path (Join-Path $PluginHome $PluginId) "current"
     $ManifestPath = Join-Path $CurrentDir "plugin.json"
@@ -243,8 +253,13 @@ function Ensure-TrustPolicy([string]$TrustPolicyUrl) {
         return
     }
     New-Item -ItemType Directory -Force -Path (Split-Path -Parent $TrustPolicyPath) | Out-Null
-    Write-Host "[kelvin] fetching official trust policy"
-    Invoke-WebRequest -Uri $TrustPolicyUrl -OutFile $TrustPolicyPath
+    if ($TrustPolicyUrl) {
+        Write-Host "[kelvin] fetching official trust policy"
+        Invoke-WebRequest -Uri $TrustPolicyUrl -OutFile $TrustPolicyPath
+        return
+    }
+    '{"require_signature":false,"publishers":[]}' | Set-Content -NoNewline $TrustPolicyPath
+    Write-Host "[kelvin] wrote permissive trust policy: $TrustPolicyPath"
 }
 
 function Extract-PackageCleanly([string]$TarballPath, [string]$ExtractDir) {
@@ -311,18 +326,38 @@ function Load-PluginManifest {
     return $Values
 }
 
+function Resolve-PluginIndexEntry([string]$PluginId, [string]$IndexUrl) {
+    if (-not $IndexUrl) {
+        throw "KELVIN_PLUGIN_INDEX_URL must be set to install '$PluginId'"
+    }
+
+    Write-Host "[kelvin] fetching plugin index"
+    $IndexJson = Invoke-RestMethod -Uri $IndexUrl -TimeoutSec 15
+    $Entries = @($IndexJson.plugins | Where-Object { $_.id -eq $PluginId })
+    if ($Entries.Count -eq 0) {
+        throw "Plugin not found in index: $PluginId"
+    }
+
+    return $Entries | Sort-Object {
+        $v = $_.version -replace '[+\-].*$', ''
+        try { [System.Version]$v } catch { [System.Version]"0.0.0" }
+    } | Select-Object -Last 1
+}
+
 function Bootstrap-OfficialPlugins {
     Require-Command "tar"
     $Manifest = Load-PluginManifest
 
-    Install-OfficialPlugin `
-        -PluginId "kelvin.cli" `
-        -Version $Manifest["KELVIN_CLI_VERSION"] `
-        -PackageUrl $Manifest["KELVIN_CLI_PACKAGE_URL"] `
-        -ExpectedSha $Manifest["KELVIN_CLI_SHA256"] `
-        -TrustPolicyUrl $Manifest["OFFICIAL_TRUST_POLICY_URL"]
+    if (-not [string]::IsNullOrWhiteSpace($Manifest["KELVIN_CLI_VERSION"])) {
+        Install-OfficialPlugin `
+            -PluginId "kelvin.cli" `
+            -Version $Manifest["KELVIN_CLI_VERSION"] `
+            -PackageUrl $Manifest["KELVIN_CLI_PACKAGE_URL"] `
+            -ExpectedSha $Manifest["KELVIN_CLI_SHA256"] `
+            -TrustPolicyUrl $Manifest["OFFICIAL_TRUST_POLICY_URL"]
+    }
 
-    if ($env:OPENAI_API_KEY) {
+    if ($env:OPENAI_API_KEY -and -not [string]::IsNullOrWhiteSpace($Manifest["KELVIN_OPENAI_VERSION"])) {
         Install-OfficialPlugin `
             -PluginId "kelvin.openai" `
             -Version $Manifest["KELVIN_OPENAI_VERSION"] `
@@ -330,6 +365,36 @@ function Bootstrap-OfficialPlugins {
             -ExpectedSha $Manifest["KELVIN_OPENAI_SHA256"] `
             -TrustPolicyUrl $Manifest["OFFICIAL_TRUST_POLICY_URL"]
     }
+}
+
+function Ensure-PluginInstalled([string]$PluginId) {
+    $CurrentVersion = Plugin-CurrentVersion $PluginId
+    if ($CurrentVersion) {
+        Ensure-TrustPolicy $null
+        return
+    }
+
+    Require-Command "tar"
+    $IndexUrl = if ($env:KELVIN_PLUGIN_INDEX_URL) { $env:KELVIN_PLUGIN_INDEX_URL } else { $DefaultPluginIndexUrl }
+    $Entry = Resolve-PluginIndexEntry -PluginId $PluginId -IndexUrl $IndexUrl
+    Write-Host "[kelvin] bootstrapping plugin: $PluginId"
+    Install-OfficialPlugin `
+        -PluginId $PluginId `
+        -Version $Entry.version `
+        -PackageUrl $Entry.package_url `
+        -ExpectedSha $Entry.sha256 `
+        -TrustPolicyUrl $Entry.trust_policy_url
+}
+
+function Ensure-RequiredPlugins([string]$PluginId) {
+    Ensure-PluginInstalled "kelvin.cli"
+
+    if ([string]::IsNullOrWhiteSpace($PluginId) -or $PluginId -eq "kelvin.echo") {
+        Ensure-TrustPolicy $null
+        return
+    }
+
+    Ensure-PluginInstalled $PluginId
 }
 
 function Invoke-KelvinInit([string[]]$InitArgs) {
@@ -450,15 +515,17 @@ foreach ($KV in $_LaunchDotenv.GetEnumerator()) {
 }
 
 Prompt-ForOpenAIKey $CliArgs
+$LaunchModelProvider = Resolve-LaunchModelProvider
 Bootstrap-OfficialPlugins
+Ensure-RequiredPlugins $LaunchModelProvider
 
 New-Item -ItemType Directory -Force -Path $StateDir | Out-Null
 $env:KELVIN_PLUGIN_HOME = $PluginHome
 $env:KELVIN_TRUST_POLICY_PATH = $TrustPolicyPath
 
 $DefaultHostArgs = @()
-if ($env:OPENAI_API_KEY) {
-    $DefaultHostArgs += @("--model-provider", "kelvin.openai")
+if ($LaunchModelProvider) {
+    $DefaultHostArgs += @("--model-provider", $LaunchModelProvider)
 }
 
 $HostBinary = Join-Path $RootDir "bin\\kelvin-host.exe"

--- a/scripts/kelvin-release-launcher.sh
+++ b/scripts/kelvin-release-launcher.sh
@@ -406,6 +406,18 @@ prompt_for_openai_api_key() {
   fi
 }
 
+resolve_launch_model_provider() {
+  if [[ -n "${KELVIN_MODEL_PROVIDER:-}" ]]; then
+    printf '%s\n' "${KELVIN_MODEL_PROVIDER}"
+    return 0
+  fi
+  if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+    printf '%s\n' 'kelvin.openai'
+    return 0
+  fi
+  printf '%s\n' ''
+}
+
 plugin_current_version() {
   local plugin_id="$1"
   local current_link="${PLUGIN_HOME}/${plugin_id}/current"
@@ -426,8 +438,13 @@ ensure_trust_policy() {
     return 0
   fi
   mkdir -p "$(dirname "${TRUST_POLICY_PATH}")"
-  echo "[kelvin] fetching official trust policy"
-  curl -fsSL "${OFFICIAL_TRUST_POLICY_URL}" -o "${TRUST_POLICY_PATH}"
+  if [[ -n "${OFFICIAL_TRUST_POLICY_URL:-}" ]]; then
+    echo "[kelvin] fetching official trust policy"
+    curl -fsSL "${OFFICIAL_TRUST_POLICY_URL}" -o "${TRUST_POLICY_PATH}"
+    return 0
+  fi
+  printf '%s' '{"require_signature":false,"publishers":[]}' > "${TRUST_POLICY_PATH}"
+  echo "[kelvin] wrote permissive trust policy: ${TRUST_POLICY_PATH}"
 }
 
 extract_package_cleanly() {
@@ -493,6 +510,41 @@ install_official_plugin() {
   rm -rf "${work_dir}"
 }
 
+install_plugin_from_index() {
+  local plugin_id="$1"
+  local index_url="${KELVIN_PLUGIN_INDEX_URL:-${DEFAULT_PLUGIN_INDEX_URL}}"
+
+  echo "[kelvin] bootstrapping plugin: ${plugin_id}"
+  "${ROOT_DIR}/share/scripts/plugin-index-install.sh" \
+    --plugin "${plugin_id}" \
+    --index-url "${index_url}" \
+    --plugin-home "${PLUGIN_HOME}" \
+    --trust-policy-path "${TRUST_POLICY_PATH}"
+}
+
+ensure_plugin_installed() {
+  local plugin_id="$1"
+  if plugin_current_version "${plugin_id}" >/dev/null 2>&1; then
+    ensure_trust_policy
+    return 0
+  fi
+
+  install_plugin_from_index "${plugin_id}"
+}
+
+ensure_required_plugins() {
+  local plugin_id="$1"
+
+  ensure_plugin_installed "kelvin.cli"
+
+  if [[ -z "${plugin_id}" || "${plugin_id}" == "kelvin.echo" ]]; then
+    ensure_trust_policy
+    return 0
+  fi
+
+  ensure_plugin_installed "${plugin_id}"
+}
+
 bootstrap_official_plugins() {
   require_cmd curl
   require_cmd tar
@@ -530,32 +582,28 @@ fi
 
 load_dotenv
 prompt_for_openai_api_key "$@"
+LAUNCH_MODEL_PROVIDER="$(resolve_launch_model_provider)"
 
 bootstrap_official_plugins
+ensure_required_plugins "${LAUNCH_MODEL_PROVIDER}"
 
 mkdir -p "${STATE_DIR}"
 export KELVIN_PLUGIN_HOME="${PLUGIN_HOME}"
 export KELVIN_TRUST_POLICY_PATH="${TRUST_POLICY_PATH}"
 
-DEFAULT_HOST_ARGS=()
-if [[ -n "${OPENAI_API_KEY:-}" ]]; then
-  DEFAULT_HOST_ARGS+=(--model-provider kelvin.openai)
-fi
-
 if [[ $# -eq 0 ]]; then
-  if [[ -t 0 && -t 1 ]]; then
-    exec "${ROOT_DIR}/bin/kelvin-host" \
-      "${DEFAULT_HOST_ARGS[@]}" \
-      --interactive \
-      --workspace "$(pwd)" \
-      --state-dir "${STATE_DIR}"
+  HOST_CMD=("${ROOT_DIR}/bin/kelvin-host")
+  if [[ -n "${LAUNCH_MODEL_PROVIDER}" ]]; then
+    HOST_CMD+=(--model-provider "${LAUNCH_MODEL_PROVIDER}")
   fi
 
-  exec "${ROOT_DIR}/bin/kelvin-host" \
-    "${DEFAULT_HOST_ARGS[@]}" \
-    --prompt "${DEFAULT_PROMPT}" \
-    --workspace "$(pwd)" \
-    --state-dir "${STATE_DIR}"
+  if [[ -t 0 && -t 1 ]]; then
+    HOST_CMD+=(--interactive --workspace "$(pwd)" --state-dir "${STATE_DIR}")
+    exec "${HOST_CMD[@]}"
+  fi
+
+  HOST_CMD+=(--prompt "${DEFAULT_PROMPT}" --workspace "$(pwd)" --state-dir "${STATE_DIR}")
+  exec "${HOST_CMD[@]}"
 fi
 
 exec "${ROOT_DIR}/bin/kelvin-host" "$@"


### PR DESCRIPTION
## Summary
- bootstrap the CLI toolpack and configured model provider from the plugin index on first run for release/Homebrew installs
- ensure a trust policy exists for clean installs and stop the no-init launcher path from failing before host startup
- pass the resolved provider through to kelvin-host and update the release docs

## Validation
- cargo fmt --all -- --check
- cargo clippy --locked --workspace -- -D warnings
- cargo test --locked --workspace
- local Homebrew reinstall against a locally packaged macOS release bundle
- clean-home smoke test for `kelvin` with no init
- clean-home smoke test for `kelvin init --provider openai && kelvin` (now reaches OpenAI auth instead of missing-plugin/trust-policy failures)

Closes #120