### PR TITLE
docs: remove stale references to deleted scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ This file defines default expectations for coding agents working in this reposit
     - Iteration/testing: use cached layers (`scripts/test-docker.sh`).
     - Final push validation: run a clean rebuild from zero (`scripts/test-docker.sh --final`).
 - Standard SDK lane:
-    - `scripts/test-sdk.sh`
+    - `cargo test -p kelvin-sdk`
 - Targeted Rust lane:
     - `cargo test -p kelvin-core -p kelvin-wasm -p kelvin-brain -p kelvin-sdk --lib`
 - Run formatting checks before finalizing:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Keep commits scoped and atomic. Only stage files relevant to the change.
 ### Testing
 
 - Add tests for new logic, data transformations, and workflow paths
-- Run `scripts/test-sdk.sh` for the SDK certification lane
+- Run `cargo test -p kelvin-sdk` for the SDK certification lane
 - Run `scripts/test-docker.sh` for Docker-based verification
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -41,11 +41,8 @@ ANTHROPIC_API_KEY=sk-ant-your-api-key-here
 ### Quick Try (local Rust)
 
 ```bash
-scripts/quickstart.sh --mode local
+cargo run -p kelvin-host -- --prompt "hello kelvin" --memory fallback
 ```
-
-Requires Rust toolchain. The quickstart prompts you to pick a model provider
-(OpenAI, Anthropic, OpenRouter) or continue with echo mode if you don't have a key.
 
 ### Install via Homebrew
 
@@ -65,14 +62,7 @@ Choose the onboarding path for your experience level:
 - [docs/GETTING_STARTED.md](docs/getting-started/GETTING_STARTED.md)
 - latest public release: [GitHub Releases](https://github.com/AgenticHighway/kelvinclaw/releases/latest)
 
-Verify a specific path:
-
-```bash
-scripts/verify-onboarding.sh --track beginner
-scripts/verify-onboarding.sh --track rust
-scripts/verify-onboarding.sh --track wasm
-scripts/verify-onboarding.sh --track daily
-```
+See [docs/getting-started/GETTING_STARTED.md](docs/getting-started/GETTING_STARTED.md) for track-specific setup guides.
 
 Plugin authors who prefer Docker over local Rust setup should use the official
 Rust Bookworm image through:
@@ -343,7 +333,7 @@ same secure installed-plugin path as third-party plugins.
 Quick run:
 
 ```bash
-scripts/try-kelvin.sh "hello"
+cargo run -p kelvin-host -- --prompt "hello" --memory fallback
 ```
 
 Interactive mode:
@@ -412,7 +402,6 @@ Methods available over the socket:
 Operational scripts (dev / CI):
 
 - `scripts/kelvin-dev-stack.sh start|stop|status|doctor`
-- `scripts/quickstart.sh --mode local|docker`
 - `scripts/docker-cache-prune.sh [--dry-run]`
 
 For end-user stack management use the `kelvin` CLI (`kelvin start`, `kelvin stop`, `kelvin gateway`, `kelvin medkit`, `kelvin doctor`).
@@ -456,22 +445,11 @@ Privacy-conscious remote setup:
 ```bash
 cp .env.example .env
 $EDITOR .env
-scripts/remote-test.sh --docker
-```
-
-Additional variants:
-
-```bash
-REMOTE_TEST_HOST=your-user@your-host scripts/remote-test.sh
-REMOTE_TEST_REMOTE_DIR=~/work/kelvinclaw scripts/remote-test.sh --native
-scripts/remote-test.sh --docker
-scripts/remote-test.sh --host your-user@your-host --cargo-args '-- --nocapture'
 ```
 
 Notes:
 
 - `.env` and `.env.local` are gitignored; keep personal hosts/IPs there only.
-- `scripts/remote-test.sh` reads `REMOTE_TEST_HOST`, `REMOTE_TEST_REMOTE_DIR`, and `REMOTE_TEST_DOCKER_IMAGE` from `.env`/`.env.local`.
 - `.env` files are parsed as key/value data and are not executed as shell code.
 
 ## Plugin Management
@@ -494,13 +472,6 @@ Default index:
 - `https://raw.githubusercontent.com/agentichighway/kelvinclaw-plugins/main/index.json`
 
 Override with `KELVIN_PLUGIN_INDEX_URL`.
-
-Installer tests:
-
-```bash
-scripts/test-plugin-install.sh
-scripts/test-cli-plugin-integration.sh
-```
 
 Hosted registry service:
 
@@ -625,7 +596,7 @@ cargo test --workspace
 SDK certification lane:
 
 ```bash
-scripts/test-sdk.sh
+cargo test -p kelvin-sdk
 ```
 
 Docker:

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -30,7 +30,7 @@ COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,target=/work/target \
-    scripts/test-sdk.sh
+    cargo test -p kelvin-sdk
 
 FROM deps AS full
 COPY . .
@@ -45,4 +45,4 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo outdated && \
     cargo test -p kelvin-core -p kelvin-wasm -p kelvin-brain -p kelvin-sdk --lib && \
     cargo test --workspace --tests && \
-    scripts/test-sdk.sh
+    cargo test -p kelvin-sdk

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -239,6 +239,5 @@ Not yet implemented:
 
 ## Operational Notes
 
-- Local remote-test helper: `scripts/remote-test.sh`
 - Remote host can be provided by `--host` or `REMOTE_TEST_HOST` (including `.env` convenience loading)
 - Build/test can run natively on ARM64 EC2 or inside Docker mode

--- a/docs/architecture/kelvin-gap-analysis.md
+++ b/docs/architecture/kelvin-gap-analysis.md
@@ -102,7 +102,7 @@ Now implemented:
 
 - `scripts/kelvin-dev-stack.sh` for local background memory+gateway lifecycle
 - actionable machine-readable doctor checks with remediation hints
-- canonical quickstart flow (`scripts/quickstart.sh`)
+- canonical quickstart flow (`docker compose up -d` / `kelvin start`)
 
 ### 3) Control UI and Operator Observability
 

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -72,16 +72,10 @@ docker compose --profile tui run --rm kelvin-tui
 
 ## Canonical Quick Start (Daily Driver MVP)
 
-Local profile (gateway + memory controller + SDK runtime):
+Docker profile (recommended):
 
 ```bash
-scripts/quickstart.sh --mode local
-```
-
-Docker profile:
-
-```bash
-scripts/quickstart.sh --mode docker
+cp .env.example .env && docker compose up -d
 ```
 
 Local profile lifecycle:
@@ -176,14 +170,7 @@ Steps:
 ```bash
 git clone <repo-url>
 cd kelvinclaw
-scripts/quickstart.sh --mode local
 cargo test -p kelvin-sdk
-```
-
-Verification:
-
-```bash
-scripts/verify-onboarding.sh --track rust
 ```
 
 Expected result:
@@ -242,7 +229,9 @@ scripts/plugin-author-docker.sh -- scripts/test-plugin-author-kit.sh
 Verification:
 
 ```bash
-scripts/verify-onboarding.sh --track wasm
+scripts/kelvin-plugin-dev.sh test --manifest ./plugin-acme.echo/plugin.json
+kelvin plugin install --package ./plugin-acme.echo/dist/acme.echo-0.1.0.tar.gz
+kelvin plugin list
 ```
 
 Expected result:
@@ -252,17 +241,6 @@ Expected result:
 - Plugin author commands scaffold and validate plugin package structure without touching root crates.
 - `kelvin plugin install` and `kelvin plugin status` cover the local package-install and model-runtime path.
 - Model plugins can be scaffolded, built, packed, and locally installed through the same public SDK surface.
-
-## Verify All Tracks
-
-Run full onboarding verification:
-
-```bash
-scripts/verify-onboarding.sh --track all
-scripts/verify-onboarding.sh --track daily
-```
-
-`all` runs `beginner`, `rust`, and `wasm`. `daily` validates the default daily-driver local profile with a time-to-first-success threshold.
 
 ## Security and Stability Notes
 

--- a/docs/getting-started/rust-developer-quickstart.md
+++ b/docs/getting-started/rust-developer-quickstart.md
@@ -6,17 +6,9 @@ For beginner and WASM-author paths, see [docs/GETTING_STARTED.md](GETTING_STARTE
 ## 1) Run Kelvin in one command
 
 ```bash
-scripts/try-kelvin.sh "hello kelvin"
+kelvin plugin install kelvin.cli
+cargo run -p kelvin-host -- --prompt "hello kelvin" --memory fallback
 ```
-
-What this does:
-
-- uses local `cargo` if installed
-- otherwise falls back to Docker (`rust:1.93.1-bookworm` by default)
-- reuses repo-local Docker cargo/build caches under `./.cache/docker` to avoid cold-start redownloads on every run
-- installs/updates the first-party `kelvin_cli` WASM plugin package from the plugin index into `./.kelvin/plugins`
-- runs `apps/kelvin-host` with a prompt
-- auto-bootstraps Rust PATH (`$HOME/.cargo/bin`, `/usr/local/cargo/bin`) before cargo/rustup checks
 
 Expected output includes:
 
@@ -25,27 +17,13 @@ Expected output includes:
 - lifecycle events (`start` / `end`)
 - assistant payload (echo provider for MVP)
 
-## 2) Force local or Docker mode
-
-```bash
-KELVIN_TRY_MODE=local scripts/try-kelvin.sh "status check"
-KELVIN_TRY_MODE=docker scripts/try-kelvin.sh "status check"
-```
-
-Optional timeout override:
-
-```bash
-KELVIN_TRY_TIMEOUT_MS=8000 scripts/try-kelvin.sh "longer timeout"
-```
-
-## 3) Validate security/stability suites
+## 2) Validate security/stability suites
 
 SDK suites:
 
 ```bash
 cargo test -p kelvin-sdk
 scripts/test-plugin-author-kit.sh
-scripts/test-plugin-trust.sh
 scripts/test-docker.sh
 ```
 
@@ -64,7 +42,7 @@ cargo test -p kelvin-memory-controller --test memory_controller_owasp_top10_ai_2
 cargo test -p kelvin-memory-controller --test memory_controller_nist_ai_rmf_1_0
 ```
 
-## 4) Current MVP behavior
+## 3) Current MVP behavior
 
 - The default demo path uses the built-in echo model provider.
 - CLI flow is SDK-first and runs through a WASM plugin (`kelvin_cli`) before run execution.

--- a/docs/plugins/plugin-install-flow.md
+++ b/docs/plugins/plugin-install-flow.md
@@ -173,12 +173,6 @@ Reference template:
 
 ## Verification
 
-Run plugin lifecycle tests:
-
-```bash
-scripts/test-plugin-install.sh
-```
-
 Authoring/packaging flow:
 
 ```bash

--- a/wiki/Development-and-Contributing.md
+++ b/wiki/Development-and-Contributing.md
@@ -30,8 +30,7 @@ KelvinClaw is structured so contributors can work safely on isolated modules wit
 Runtime contributors:
 
 ```bash
-scripts/quickstart.sh --mode local
-scripts/test-sdk.sh
+cargo test -p kelvin-sdk
 cargo test --workspace --tests
 ```
 

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -41,16 +41,10 @@ docker compose run kelvin-tui
 
 ## Quick Start Paths
 
-Daily-driver local profile:
+Docker (recommended):
 
 ```bash
-scripts/quickstart.sh --mode local
-```
-
-Docker-only profile:
-
-```bash
-scripts/quickstart.sh --mode docker
+cp .env.example .env && docker compose up -d
 ```
 
 Local profile lifecycle:
@@ -95,7 +89,7 @@ Bootstrap:
 ```bash
 git clone https://github.com/AgenticHighway/kelvinclaw.git
 cd kelvinclaw
-scripts/quickstart.sh --mode local
+kelvin init
 cargo test -p kelvin-sdk
 ```
 
@@ -124,7 +118,7 @@ scripts/kelvin-plugin-dev.sh test --manifest ./plugin-acme.echo/plugin.json
 Single prompt:
 
 ```bash
-scripts/try-kelvin.sh "hello"
+cargo run -p kelvin-host -- --prompt "hello" --memory fallback
 ```
 
 Interactive host:

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -26,8 +26,9 @@ KelvinClaw keeps trusted code in the host/runtime path and pushes installable ex
 Quick start:
 
 ```bash
-scripts/quickstart.sh --mode local
-scripts/quickstart.sh --mode docker
+cp .env.example .env
+docker compose up -d
+docker compose --profile tui run --rm kelvin-tui
 ```
 
 Local profile lifecycle:

--- a/wiki/Operations-and-Runbooks.md
+++ b/wiki/Operations-and-Runbooks.md
@@ -92,8 +92,6 @@ scripts/docker-cache-prune.sh --max-age-days 14
 ## Useful Operational Scripts
 
 - `scripts/memory-rollout-check.sh`
-- `scripts/first-run-success-rate.sh`
-- `scripts/remote-test.sh`
 
 ## Reference
 

--- a/wiki/Testing-and-Validation.md
+++ b/wiki/Testing-and-Validation.md
@@ -64,9 +64,7 @@ cargo test -p kelvin-registry
 Plugin lifecycle:
 
 ```bash
-scripts/test-plugin-install.sh
 scripts/test-plugin-author-kit.sh
-scripts/test-plugin-trust.sh
 scripts/test-plugin-abi-compat.sh
 ```
 


### PR DESCRIPTION
## Summary

- Removes references to ~30 shell scripts that were deleted as part of the `apps/kelvin-cli` unification (`feat/unified-kelvin-cli`)
- Affects `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, wiki pages, docs, and `docker/Dockerfile.test`
- Replaces deleted script invocations with their `kelvin` CLI equivalents or `cargo` commands

## Test plan

- [ ] Verify no remaining references to deleted scripts: `grep -r 'scripts/quickstart\.sh\|scripts/verify-onboarding\.sh\|scripts/test-sdk\.sh\|scripts/try-kelvin\.sh\|scripts/remote-test\.sh' --include='*.md' --include='*.rs' --include='*.sh' .`