### PR TITLE
Migrate macOS ARM release to Blacksmith

### DIFF
--- a/.github/workflows/release-executables.yml
+++ b/.github/workflows/release-executables.yml
@@ -143,10 +143,19 @@ jobs:
                 include:
                     - runner: macos-15-intel
                       target: x86_64-apple-darwin
-                    - runner: macos-15
+                    # Blacksmith macOS runners are Apple Silicon only, so keep
+                    # the x86_64 artifact on GitHub-hosted Intel macOS.
+                    - runner: blacksmith-6vcpu-macos-15
                       target: aarch64-apple-darwin
         steps:
             - name: Checkout
+              if: startsWith(matrix.runner, 'blacksmith-')
+              uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b
+              with:
+                  persist-credentials: false
+
+            - name: Checkout
+              if: ${{ !startsWith(matrix.runner, 'blacksmith-') }}
               uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
               with:
                   persist-credentials: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4001,9 +4001,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/apps/kelvin-tui/src/app.rs
+++ b/apps/kelvin-tui/src/app.rs
@@ -1392,21 +1392,21 @@ async fn run_loop(
                         assert_markers_valid(&app.input, &app.paste_markers);
                         update_autocomplete(app);
                     }
-                    KeyCode::Tab => {
-                        if app.autocomplete_visible && !app.autocomplete_items.is_empty() {
-                            app.autocomplete_selected =
-                                (app.autocomplete_selected + 1) % app.autocomplete_items.len();
-                            sync_autocomplete_scroll(app);
-                        }
+                    KeyCode::Tab
+                        if app.autocomplete_visible && !app.autocomplete_items.is_empty() =>
+                    {
+                        app.autocomplete_selected =
+                            (app.autocomplete_selected + 1) % app.autocomplete_items.len();
+                        sync_autocomplete_scroll(app);
                     }
-                    KeyCode::BackTab => {
-                        if app.autocomplete_visible && !app.autocomplete_items.is_empty() {
-                            app.autocomplete_selected = app
-                                .autocomplete_selected
-                                .checked_sub(1)
-                                .unwrap_or(app.autocomplete_items.len() - 1);
-                            sync_autocomplete_scroll(app);
-                        }
+                    KeyCode::BackTab
+                        if app.autocomplete_visible && !app.autocomplete_items.is_empty() =>
+                    {
+                        app.autocomplete_selected = app
+                            .autocomplete_selected
+                            .checked_sub(1)
+                            .unwrap_or(app.autocomplete_items.len() - 1);
+                        sync_autocomplete_scroll(app);
                     }
                     KeyCode::Backspace => {
                         app.do_backspace();
@@ -1583,15 +1583,15 @@ async fn run_loop(
                         app.selection = None;
                     }
                 }
-                MouseEventKind::Drag(MouseButton::Left) => {
-                    if in_rect(ev.column, ev.row, app.chat_area) {
-                        let is_chat_sel =
-                            matches!(&app.selection, Some(s) if s.target == SelectionTarget::Chat);
-                        if is_chat_sel {
-                            let pos = screen_to_chat_pos(ev.column, ev.row, app);
-                            if let (Some(pos), Some(ref mut sel)) = (pos, app.selection.as_mut()) {
-                                sel.extent = pos;
-                            }
+                MouseEventKind::Drag(MouseButton::Left)
+                    if in_rect(ev.column, ev.row, app.chat_area) =>
+                {
+                    let is_chat_sel =
+                        matches!(&app.selection, Some(s) if s.target == SelectionTarget::Chat);
+                    if is_chat_sel {
+                        let pos = screen_to_chat_pos(ev.column, ev.row, app);
+                        if let (Some(pos), Some(ref mut sel)) = (pos, app.selection.as_mut()) {
+                            sel.extent = pos;
                         }
                     }
                 }

--- a/crates/kelvin-sdk/src/scheduler/persistence.rs
+++ b/crates/kelvin-sdk/src/scheduler/persistence.rs
@@ -44,9 +44,7 @@ pub(super) fn save_state(path: &Path, state: &mut SchedulerState) -> KelvinResul
             .cmp(&right.schedule_id)
             .then_with(|| left.slot_at_ms.cmp(&right.slot_at_ms))
     });
-    state
-        .audit
-        .sort_by(|left, right| left.ts_ms.cmp(&right.ts_ms));
+    state.audit.sort_by_key(|entry| entry.ts_ms);
     if state.slots.len() > MAX_SLOT_ENTRIES {
         let keep_from = state.slots.len().saturating_sub(MAX_SLOT_ENTRIES);
         state.slots.drain(..keep_from);

--- a/crates/kelvin-sdk/src/scheduler/store.rs
+++ b/crates/kelvin-sdk/src/scheduler/store.rs
@@ -121,7 +121,7 @@ impl SchedulerStore {
             if let Some(schedule_id) = schedule_id {
                 slots.retain(|slot| slot.schedule_id == schedule_id);
             }
-            slots.sort_by(|left, right| right.slot_at_ms.cmp(&left.slot_at_ms));
+            slots.sort_by_key(|slot| std::cmp::Reverse(slot.slot_at_ms));
             slots.truncate(limit.max(1));
             slots
         })
@@ -137,7 +137,7 @@ impl SchedulerStore {
             if let Some(schedule_id) = schedule_id {
                 audit.retain(|entry| entry.schedule_id.as_deref() == Some(schedule_id));
             }
-            audit.sort_by(|left, right| right.ts_ms.cmp(&left.ts_ms));
+            audit.sort_by_key(|entry| std::cmp::Reverse(entry.ts_ms));
             audit.truncate(limit.max(1));
             audit
         })


### PR DESCRIPTION
## Summary
- move the macOS ARM64 release matrix leg to the pinned Blacksmith macOS 15 runner
- keep the x86_64 macOS release artifact on GitHub-hosted Intel macOS because Blacksmith macOS runners are ARM64 only
- use Blacksmith checkout only for the Blacksmith-backed macOS leg
- fix current CI blockers by applying Clippy sort suggestions and updating rustls-webpki to 0.103.13 for RUSTSEC-2026-0104

Closes #128

## Validation
- Parsed .github/workflows/release-executables.yml with Ruby YAML loader
- Ran git diff --check
- Ran cargo fmt --all -- --check
- Ran cargo clippy --locked --workspace -- -D warnings